### PR TITLE
[FIX] Fixed opening lightbox from other columns

### DIFF
--- a/source/js/content.js
+++ b/source/js/content.js
@@ -547,6 +547,11 @@ function createPreviewDiv(element, provider) {
 		previewLink.href = linkURL;
 		previewLink.setAttribute("target","_blank");
 		previewLink.setAttribute("data-tweetkey",element.parentNode.parentNode.parentNode.parentNode.parentNode.getAttribute("data-key"));
+		
+		if(element.parentNode.parentNode.parentNode.parentNode.parentNode.getAttribute("data-key") == null) {
+			previewLink.setAttribute("data-tweetkey",element.parentNode.parentNode.parentNode.parentNode.parentNode.parentNode.getAttribute("data-key"));
+		}
+		
 		// Applying our thumbnail as a background-image of the preview div
 		previewLink.style.backgroundImage = "url("+thumbnailUrl+")";
 		previewLink.setAttribute("data-provider",provider);


### PR DESCRIPTION
When clicking a thumbnail from the notifications column, it would give an error. That should be fixed.
