### PR TITLE
[FIX] Existing modal can still be loading

### DIFF
--- a/source/js/content.js
+++ b/source/js/content.js
@@ -231,7 +231,7 @@ function eventDispatcher() {
 				injectScript(getTDTheme);
 			});
 		};
-	} else if(event.relatedNode.classList.contains('js-modal-content')) {
+	} else if(event.relatedNode.classList.contains('js-modal-content') && !event.relatedNode.firstChild.classList.contains('is-loading')) {
 		event.target.querySelector("a.prf-siteurl").href = "http://"+event.target.querySelector("a.prf-siteurl").innerText;
 	}
 }


### PR DESCRIPTION
This removes `Uncaught TypeError: Cannot read property 'innerText' of null` exceptions while opening a profile modal.
The exception was happening while trying to replace the .siteurl's href with the direct link.

(I have no idea what github's editor is trying to do on line 849, sorry)
