### PR TITLE
Fixed typo and link

### DIFF
--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -91,7 +91,7 @@
 
   "donate_title":  { "message": "Aidez-moi à maintenir Better TweetDeck!" },
   "donate_p3":  { "message": "Merci d'utiliser Better TweetDeck et d'aider à le garder en vie!" },
-  "donate_p2":  { "message": "Si vous pouvew vous le permettre et vous sentez généreux, cela serait <strong>incroyable</strong> si vous pouviez a href='https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=XK9SQ6ZDE9UF2&lc=US&item_name=Damien%20Erambert&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted'>donner sur Paypal</a> ou <a href='https://patreon.com/eramdam'>me supporter sur Patreon</a> (et ainsi avoir accès à des pré-versions de Better TweetDeck!)
+  "donate_p2":  { "message": "Si vous pouvez vous le permettre et vous sentez généreux, cela serait <strong>incroyable</strong> si vous pouviez <a href='https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=XK9SQ6ZDE9UF2&lc=US&item_name=Damien%20Erambert&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donate_SM%2egif%3aNonHosted'>donner sur Paypal</a> ou <a href='https://patreon.com/eramdam'>me supporter sur Patreon</a> (et ainsi avoir accès à des pré-versions de Better TweetDeck!)
     <br><br>
     Même la plus petite contribution aide!" },
   "donate_p1": { "message": "Better TweetDeck est et sera toujours <strong>gratuit</strong> mais le développer prend du temps et coûte de l'argent


### PR DESCRIPTION
Saw this weirdly-looking paragraph in the French version
![capture d ecran de 2016-08-07 19-20-23](https://cloud.githubusercontent.com/assets/5547783/17463984/1313ddd8-5cd4-11e6-95a3-2f48915b6245.png)

Fixed:

* HTML link to Paypal
* Typo in "pouvez"