### PR TITLE
Add feature to collapse read direct messages

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -41,6 +41,7 @@
   "title_avatars": { "message": "Avatars & details" },
   "css_round_pic": { "message": "Rounded avatars" },
   "css_bigger_emojis": { "message": "Bigger emojis in tweets" },
+  "css_collapse_dms": { "message": "Collapse read direct messages" },
   "css_show_verified": { "message": "Show 'verified' badges" },
   "css_hide_context": { "message": "Hide 'In reply to' label on mentions" },
   "css_actions_on_right": { "message": "Show tweet actions on the right" },

--- a/src/css/features/collapse-dms.css
+++ b/src/css/features/collapse-dms.css
@@ -1,0 +1,26 @@
+.btd__collapse_dms .tweet-message .l-table {
+  display: none !important;
+}
+
+.btd__collapse_dms .tweet-message .tweet-avatar {
+  width: 24px;
+  height: 24px;
+}
+  
+.btd__collapse_dms .is-unread .tweet-message .l-table {
+  display: table !important;
+  vertical-align: middle;
+}
+  
+.btd__collapse_dms .tweet-message .conversation-indicator {
+  display: none;
+}
+
+.btd__collapse_dms .tweet-message .nbfc {
+  margin-left: -25px;
+  line-height: 1.6em; 	
+}
+
+.btd__collapse_dms .tweet-message .tweet-text {
+  margin-left: -24px;	
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -6,6 +6,7 @@
 /* Visual Features */
 @import './features/actions.css';
 @import './features/bigger-emojis.css';
+@import './features/collapse-dms.css';
 @import './features/flash-tweets.css';
 @import './features/gray-notif-icns.css';
 @import './features/hide-context.css';

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -29,6 +29,7 @@ const defaultSettings = {
   css: {
     round_pic: true,
     bigger_emojis: true,
+    collapse_dms: false,
     no_col_icns: false,
     gray_icns_notifs: false,
     minimal_mode: false,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -261,6 +261,10 @@
             <label for="gray_icns_notifs" data-lang="css_gray_icns_notifs">Notifications icons are in grayscale</label>
           </li>
           <li>
+            <input type="checkbox" name="css.collapse_dms" id="collapse_dms">
+            <label for="bigger_emojis" data-lang="css_collapse_dms" data-new-feat >Collapse read direct messages</label>
+          </li>
+          <li>
             <input type="checkbox" name="custom_columns_width.enabled" id="column_width" data-ghost><label for="column_width" data-lang="custom_width_columns" data-new-feat>Custom width for columns:</label>
             <ul>
               <li>


### PR DESCRIPTION
This feature adds the ability to collapse read direct messages, meaning only unread direct messages will have their full text (or preview) displayed.

The styling and positioning of the usernames and dates might look a bit off, but considering there might be changes to it very often over time it is more effort to keep the positioning accurate based on magic numbers than just keeping it the way it is, it's not off too much off anyway and people adjust to change rather quickly.