### PR TITLE
Add supports of Pixiv & twipple thumbnails

### DIFF
--- a/src/js/util/providers/index.js
+++ b/src/js/util/providers/index.js
@@ -23,3 +23,5 @@ export { default as universal } from './universal';
 export { default as vimeo } from './vimeo';
 export { default as yfrog } from './yfrog';
 export { default as youtube } from './youtu_be';
+export { default as twipple } from './twipple';
+export { default as pixiv } from './pixiv';

--- a/src/js/util/providers/pixiv.js
+++ b/src/js/util/providers/pixiv.js
@@ -1,0 +1,33 @@
+export default function ($) {
+  return {
+    name: 'Pixiv',
+    setting: 'pixiv',
+    re: /(?:pixiv.net\/member_illust.php|pixiv.net\/i\/)/,
+    default: true,
+    callback: url => {
+      let illustId;
+      if (url.includes('member_illust.php')) {
+        const _url = new URL(url);
+        illustId = _url.searchParams.get('illust_id');
+      } else {
+        illustId = url.slice(url.lastIndexOf('/') + 1);
+      }
+      return fetch($.getSafeURL(`${$.getEnpointFor('pixiv')}${illustId}`))
+        .then((res) => res.text())
+        .then((res) => {
+          const match = res.match(/callback\((.*)\)/);
+          const data = JSON.parse(match[1]);
+          return data;
+        })
+        .then(data => {
+          const thumbnailUrl = $.getSafeURL(data.img.replace('240x480', '600x600'));
+          const imgUrl = $.getSafeURL(data.img.replace('240x480', '1200x1200'));
+          return {
+            type: 'image',
+            thumbnail_url: thumbnailUrl,
+            url: $.getSafeURL(imgUrl),
+          };
+        });
+    },
+  };
+}

--- a/src/js/util/providers/twipple.js
+++ b/src/js/util/providers/twipple.js
@@ -1,0 +1,16 @@
+export default function ($) {
+  return {
+    name: 'twipple',
+    setting: 'twipple',
+    re: /(?:p.twipple.jp|p.twpl.jp)/,
+    default: true,
+    callback: url => {
+      const imageId = url.slice(url.lastIndexOf('/') + 1);
+      return Promise.resolve({
+        type: 'image',
+        thumbnail_url: $.getSafeURL(`http://p.twipple.jp/show/large/${imageId}`),
+        url: $.getSafeURL(`http://p.twipple.jp/show/orig/${imageId}`),
+      });
+    },
+  };
+}

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -16,6 +16,7 @@ const endpoints = {
   instagram: 'https://api.instagram.com/oembed?url=',
   twitch: 'https://api.twitch.tv/kraken/',
   giphy: 'https://giphy.com/services/oembed?url=',
+  pixiv: 'http://embed.pixiv.net/embed_json.php?callback=callback&size=medium&id=',
 };
 
 let providersSettings;
@@ -130,6 +131,8 @@ const schemeWhitelist = [
   Providers.youtube(util),
   Providers.yfrog(util),
   Providers.universal(util),
+  Providers.twipple(util),
+  Providers.pixiv(util),
 ];
 
 const validateUrl = (url) => {
@@ -160,7 +163,10 @@ const validateUrl = (url) => {
 function thumbnailForFetch(url) {
   const validationObj = validateUrl(url);
   const cleanUrl = new URL(url);
-  cleanUrl.search = '';
+  // Pixiv requires url parameters
+  if (cleanUrl && !cleanUrl.hostname.includes('pixiv.')) {
+    cleanUrl.search = '';
+  }
   url = cleanUrl.toString();
 
   if (!validationObj.cb) {


### PR DESCRIPTION
- [Pixiv](https://pixiv.net): Most popular Japanese fanart & illustration community like [DeviantArt](https://deviantart.com)
- [twipple](http://twipple.jp): Twitter client and image sharing service provided by BIGLOBE, a famous Japanese ISP

You can test thumbnail preview by searching "p.twpl.jp OR p.twipple.jp" or "#pixiv \<your favorite works>" on TweetDeck.