### PR TITLE
Fix settings dump styling

### DIFF
--- a/src/css/options/tokens.css
+++ b/src/css/options/tokens.css
@@ -24,3 +24,11 @@ span.token.-bugfix {
 span.token.-improvement {
   background-color: hsl(47, 99%, 60%);
 }
+
+.settings-dump .token {
+  text-transform: initial;
+  background-image: none;
+  box-shadow: none;
+  padding: 0;
+  text-shadow: none;
+}


### PR DESCRIPTION
Someone probably forgot that `.token` is already used somewhere :P 

Fixes:
![](https://jii.moe/HyJ1pHywx.png)

Back to this:
![](https://jii.moe/HkJy6rkPl.png)