### PR TITLE
add support of Amazon.com via noembed

### DIFF
--- a/src/js/util/providers/amazon.js
+++ b/src/js/util/providers/amazon.js
@@ -1,0 +1,27 @@
+export default function ($) {
+  return {
+    name: 'Amazon.com',
+    setting: 'amazon',
+    re: /(?:amzn.com|amazon.com)/,
+    default: true,
+    callback: url => {
+      return fetch(`${$.getEnpointFor('noembed')}${url}`)
+        .then($.statusAndJson)
+        .then(data => {
+          if (!data.html) {
+            return undefined;
+          }
+
+          // Use large size image instead of tiny one
+          const imgUrl = /<img.+?src="(.+?)"/.exec(data.html)[1].replace('._SL110_', '');
+          const obj = {
+            type: 'image',
+            thumbnail_url: $.getSafeURL(imgUrl),
+            url: $.getSafeURL(imgUrl),
+          };
+
+          return obj;
+        });
+    },
+  };
+}

--- a/src/js/util/providers/index.js
+++ b/src/js/util/providers/index.js
@@ -25,3 +25,4 @@ export { default as yfrog } from './yfrog';
 export { default as youtube } from './youtu_be';
 export { default as twipple } from './twipple';
 export { default as pixiv } from './pixiv';
+export { default as amazon } from './amazon';

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -133,6 +133,7 @@ const schemeWhitelist = [
   Providers.universal(util),
   Providers.twipple(util),
   Providers.pixiv(util),
+  Providers.amazon(util),
 ];
 
 const validateUrl = (url) => {


### PR DESCRIPTION
https://noembed.com/ only supports old style URLs using HTTP protocol, so we can now show thumbnails whose url starts with `http://www.amazon.com/` or `http://amzn.com/` but not `https://www.amazon.com/` etc.

So I've made [Pull requests](https://github.com/leedo/noembed/pull/84) for leedo/noembed to fix this problem. Since this repository seems to be not so active, if PR would be merged, I assume it may take some days.