### PR TITLE
add support of TINAMI

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "run-sequence": ">=1.1.2",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": ">=1.1.0",
-    "vinyl-transform": "^1.0.0"
+    "vinyl-transform": "^1.0.0",
+    "xml-js": "^1.0.0"
   }
 }

--- a/src/js/util/providers/index.js
+++ b/src/js/util/providers/index.js
@@ -25,3 +25,4 @@ export { default as yfrog } from './yfrog';
 export { default as youtube } from './youtu_be';
 export { default as twipple } from './twipple';
 export { default as pixiv } from './pixiv';
+export { default as tinami } from './tinami';

--- a/src/js/util/providers/tinami.js
+++ b/src/js/util/providers/tinami.js
@@ -1,0 +1,38 @@
+import convert from 'xml-js';
+
+export default function ($) {
+  return {
+    name: 'TINAMI',
+    setting: 'tinami',
+    re: /(?:www.tinami.com\/view|tinami.jp\/)/,
+    default: true,
+    callback: url => {
+      let imageId = url.slice(url.lastIndexOf('/') + 1);
+      // If short url, encode ID with base 36
+      if (url.includes('tinami.jp')) {
+        imageId = parseInt(imageId, 36);
+      }
+
+      return fetch($.getSafeURL(
+        `${$.getEnpointFor('tinami')}cont_id=${imageId}&api_key=${$.getKeyFor('tinami')}`))
+        .then($.statusAndText)
+        .then(xml => convert.xml2js(xml, {compact: true}))
+        .then(json => {
+          // Quit if there is non-public image or no image
+          if (json.rsp._attributes.stat != 'ok' ||
+              json.rsp.content._attributes.type == 'novel') {
+            return;
+          }
+          const image = json.rsp.content.image ||
+                json.rsp.content.images.image[0] ||
+                json.rsp.content.images.image;
+          const imgUrl = $.getSafeURL(image.url._text);
+          return Promise.resolve({
+            type: 'image',
+            thumbnail_url: imgUrl,
+            url: imgUrl,
+          });
+        });
+    },
+  };
+}

--- a/src/js/util/providers/tinami.js
+++ b/src/js/util/providers/tinami.js
@@ -7,26 +7,26 @@ export default function ($) {
     re: /(?:www.tinami.com\/view|tinami.jp\/)/,
     default: true,
     callback: url => {
-      let imageId = url.slice(url.lastIndexOf('/') + 1);
+      let imageId = new URL(url).pathname.split('/').pop();
       // If short url, encode ID with base 36
       if (url.includes('tinami.jp')) {
         imageId = parseInt(imageId, 36);
       }
-
       return fetch($.getSafeURL(
         `${$.getEnpointFor('tinami')}cont_id=${imageId}&api_key=${$.getKeyFor('tinami')}`))
         .then($.statusAndText)
         .then(xml => convert.xml2js(xml, {compact: true}))
         .then(json => {
           // Quit if there is non-public image or no image
-          if (json.rsp._attributes.stat != 'ok' ||
+          if (json.rsp._attributes.stat !== 'ok' ||
               json.rsp.content._attributes.type == 'novel') {
             return;
           }
           const image = json.rsp.content.image ||
                 json.rsp.content.images.image[0] ||
                 json.rsp.content.images.image;
-          const imgUrl = $.getSafeURL(image.url._text);
+          const imgUrl = $.getSafeURL(image.url._text.replace(
+            'http://api.tinami.com/', 'https://www.tinami.com/api/'));
           return Promise.resolve({
             type: 'image',
             thumbnail_url: imgUrl,

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -17,6 +17,7 @@ const endpoints = {
   twitch: 'https://api.twitch.tv/kraken/',
   giphy: 'https://giphy.com/services/oembed?url=',
   pixiv: 'http://embed.pixiv.net/embed_json.php?callback=callback&size=medium&id=',
+  tinami: 'https://www.tinami.com/api/content/info?',
 };
 
 let providersSettings;
@@ -68,6 +69,16 @@ const statusAndJson = res => {
 };
 
 /**
+ * Function to use in promise that will return the text output of a request
+ */
+const statusAndText = res => {
+  if (res.status >= 200 && res.status < 300) {
+    return res.text();
+  }
+  return Promise.reject(new Error(res.statusText));
+}
+
+/**
  * Returns a promise with image data from noembed
  */
 const noEmbedImgCB = url => {
@@ -103,7 +114,7 @@ const noEmbedVideoCB = url => {
 };
 
 // We export a few useful functions for providers
-const util = { getKeyFor, statusAndJson, getEnpointFor, getSafeURL, noEmbedVideoCB, noEmbedImgCB };
+const util = { getKeyFor, statusAndJson, statusAndText, getEnpointFor, getSafeURL, noEmbedVideoCB, noEmbedImgCB };
 
 const schemeWhitelist = [
   Providers.fivehundredpx(util),
@@ -133,6 +144,7 @@ const schemeWhitelist = [
   Providers.universal(util),
   Providers.twipple(util),
   Providers.pixiv(util),
+  Providers.tinami(util),
 ];
 
 const validateUrl = (url) => {


### PR DESCRIPTION
[TINAMI](https://tinami.com) is one of famous Japanese illustration community for fans of anime and comics like Pixiv.

To use TINAMI API, we need to get TINAMI API key. Could you make a request for TINAMI API? It\'s not difficult and I think it takes only a few minutes. Here is workflow needed:

1. Register to TINAMI.
2. Make a request for TINAMI API.
3. Edit `config/default.js` to add a given key to `Client.APIs.tinami`. That\'s all.

You can easily [register to TINAMI](http://www.tinami.com/login?lang=en) via Twitter account, and fill forms in [API Request Form](www.tinami.com/api/key/form).

I translated **API Request form** and **API Guideline** to English for your reference. Visit here: https://gist.github.com/shuuji3/a7185b39c5c73a2ddbeb54682b1f81c8

You can test TINAMI provider by searching for [@tinami_hot](https://twitter.com/tinami_hot).

I added `xml-js`(a XML parser) to `packages.json`, because TINAMI API only supports XML response.

I'm inexperienced with JavaScript, feel free to give a comment if I made something wrong! 

Thank you.