### PR TITLE
Add support of Gyazo

### DIFF
--- a/src/js/util/providers/gyazo.js
+++ b/src/js/util/providers/gyazo.js
@@ -1,0 +1,21 @@
+export default function ($) {
+  return {
+    name: 'Gyazo',
+    setting: 'gyazo',
+    re: /gyazo.com/,
+    default: true,
+    callback: url => {
+      return fetch($.getSafeURL(`${$.getEnpointFor('gyazo')}${url}`))
+        .then($.statusAndJson)
+        .then(data => {
+          const obj = {
+            type: 'image',
+            thumbnail_url: $.getSafeURL(data.url),
+            url: $.getSafeURL(data.url),
+          };
+
+          return obj;
+        });
+    },
+  };
+}

--- a/src/js/util/providers/index.js
+++ b/src/js/util/providers/index.js
@@ -27,3 +27,4 @@ export { default as twipple } from './twipple';
 export { default as pixiv } from './pixiv';
 export { default as tinami } from './tinami';
 export { default as nicoseiga } from './nicoseiga';
+export { default as gyazo } from './gyazo';

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -19,6 +19,7 @@ const endpoints = {
   pixiv: 'http://embed.pixiv.net/embed_json.php?callback=callback&size=medium&id=',
   tinami: 'https://www.tinami.com/api/content/info?',
   nicoseiga: 'http://ext.seiga.nicovideo.jp/thumb/',
+  gyazo: 'https://api.gyazo.com/api/oembed?url=',
 };
 
 let providersSettings;
@@ -126,6 +127,7 @@ const schemeWhitelist = [
   Providers.dribbble(util),
   Providers.droplr(util),
   Providers.flickr(util),
+  Providers.gyazo(util),
   Providers.gfycat(util),
   Providers.giphy(util),
   Providers.imgur(util),


### PR DESCRIPTION
[Gyazo](https://gyazo.com/en) is a screenshot and screenshot GIF sharing service.

Gyazo's API requires an access token. Cloud you get one [here](https://gyazo.com/api?lang=en)?

Test URLs (GIF screenshot of BTD's GIF preview):
- https://gyazo.com/5fc7cfdd3aa6bb36fd6ee7a93c0659d7
- https://gyazo.com/59916a38f8423b6622444ec7c3d7eb28

Or try search `gyazo.com`.