### PR TITLE
Make embeds larger on smaller screens

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -147,3 +147,11 @@ iframe.imgur-album {
 body :matches(.tweet-avatar, .prf-img, .avatar, .compose-account) {
   border-radius: 10% !important;
 }
+
+@media (max-height: 720px) {
+  [data-btdtheme] .med-embeditem {
+    top: 30px;
+    bottom: 130px;
+  }
+}
+    


### PR DESCRIPTION
This pull request makes embedded content larger on smaller (<=720p) screens.

![screenshot 2017-02-14 12 12 07](https://cloud.githubusercontent.com/assets/284395/22927103/dba328e6-f2af-11e6-80ee-21704b151621.jpg)
