### PR TITLE
Update Tumblr provider

### DIFF
--- a/src/js/util/providers/tumblr.js
+++ b/src/js/util/providers/tumblr.js
@@ -9,17 +9,25 @@ export default function ($) {
         $.getSafeURL(`${$.getEnpointFor('embedly')}key=${$.getKeyFor('embedly')}&url=${url}`))
         .then($.statusAndJson)
         .then(json => {
-          if (json.type !== 'photo') {
-            return undefined;
+          if (json.type === 'photo') {
+            const thumbnailUrl = json.thumbnail_url.replace(json.thumbnail_width, '500').replace('http:', 'https:');
+            const imgUrl = json.url.replace('http:', 'https:');
+            const obj = {
+              type: 'image',
+              thumbnail_url: $.getSafeURL(thumbnailUrl),
+              url: $.getSafeURL(imgUrl),
+            };
+            return obj;
+          } else if (json.type === 'video') {
+            const obj = {
+              type: 'video',
+              thumbnail_url: $.getSafeURL(json.thumbnail_url),
+              html: json.html,
+              url,
+            };
+            return obj;
           }
-          const thumbnailUrl = json.thumbnail_url.replace(json.thumbnail_width, '500').replace('http:', 'https:');
-          const imgUrl = json.url.replace('http:', 'https:');
-          const obj = {
-            type: 'image',
-            thumbnail_url: $.getSafeURL(thumbnailUrl),
-            url: $.getSafeURL(imgUrl),
-          };
-          return obj;
+          return undefined;
         });
     },
   };

--- a/src/js/util/providers/tumblr.js
+++ b/src/js/util/providers/tumblr.js
@@ -8,9 +8,12 @@ export default function ($) {
     default: true,
     callback: url => {
       // Resolve url redirect of tmblr.co
-      if (/tmblr.co/.test(url)) {
-        const r = request.get($.getSafeURL(url));
-        url = r.uri.href.replace('http:', 'https:');
+      if (/tmblr.co/.test(const)) {
+        url = requestUrl = $.getSafeURL(`${$.getEnpointFor('expandurl')}${url}`);
+        request.get({
+          url: requestUrl,
+          json: true,
+        }, (err, res, body) => { url = body.end_url; });
       }
       const match = /([^/]+.tumblr.com)\/\w+\/(\d+)/.exec(url);
       const domain = match[1];
@@ -29,10 +32,13 @@ export default function ($) {
             };
             return obj;
           } else if (post.type === 'video') {
+            const html = fetch($.getSafeURL(`${$.getEnpointFor('tumblr_oembed')}${url}`))
+                  .then($.statusAndJson)
+                  .then(data => data.html)();
             const obj = {
               type: 'video',
               thumbnail_url: $.getSafeURL(post.thumbnail_url.replace('http:', 'https:')),
-              html: post.player.slice(-1)[0].embed_code,
+              html,
               url,
             };
             return obj;

--- a/src/js/util/providers/tumblr.js
+++ b/src/js/util/providers/tumblr.js
@@ -2,12 +2,25 @@ export default function ($) {
   return {
     name: 'Tumblr',
     setting: 'tumblr',
-    re: /tumblr.com\/.+.(?:gif|png|jpg)$/,
+    re: /(?:tumblr.com|tmblr.co)/,
     default: true,
-    callback: url => Promise.resolve({
-      type: 'image',
-      thumbnail_url: $.getSafeURL(url),
-      url: $.getSafeURL(url),
-    }),
+    callback: url => {
+      return fetch(
+        $.getSafeURL(`${$.getEnpointFor('embedly')}key=${$.getKeyFor('embedly')}&url=${url}`))
+        .then($.statusAndJson)
+        .then(json => {
+          if (json.type !== 'photo') {
+            return undefined;
+          }
+          const thumbnailUrl = json.thumbnail_url.replace(json.thumbnail_width, '500').replace('http:', 'https:');
+          const imgUrl = json.url.replace('http:', 'https:');
+          const obj = {
+            type: 'image',
+            thumbnail_url: $.getSafeURL(thumbnailUrl),
+            url: $.getSafeURL(imgUrl),
+          };
+          return obj;
+        });
+    },
   };
 }

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -19,6 +19,7 @@ const endpoints = {
   pixiv: 'http://embed.pixiv.net/embed_json.php?callback=callback&size=medium&id=',
   tinami: 'https://www.tinami.com/api/content/info?',
   nicoseiga: 'http://ext.seiga.nicovideo.jp/thumb/',
+  tumblr: 'https://api.tumblr.com/v2/blog/',
 };
 
 let providersSettings;

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -20,6 +20,8 @@ const endpoints = {
   tinami: 'https://www.tinami.com/api/content/info?',
   nicoseiga: 'http://ext.seiga.nicovideo.jp/thumb/',
   tumblr: 'https://api.tumblr.com/v2/blog/',
+  tumblr_oembed: 'https://www.tumblr.com/oembed/1.0/?url=',
+  expandurl: 'http://redirect-test-for-btd.appspot.com/expand?url=',
 };
 
 let providersSettings;


### PR DESCRIPTION
This PR update Tumblr provider to use Embedly API. This enables to handle these cases:
- URL is `tmblr.co` shorturl created by Tumblr
- URL doesn't include extensions such as `png`, `jpg`, `gif`
  - In fact, URLs ending with these extensions have already covered by Universal provider :)
- Video post

Test URLs:
- video: http://lexiconluthor.tumblr.com/post/156902905127/owl-be-clean-in-no-time
- image: http://s-ockerdricka.tumblr.com/post/80584073975/really-amazing-fanarts-by-irua
- gif: http://notsuki.tumblr.com/post/94554364226