### PR TITLE
WIP: Documentation

### DIFF
--- a/docs/extend/css-features.md
+++ b/docs/extend/css-features.md
@@ -1,0 +1,35 @@
+# Extend BetterTweetDeck with CSS Features
+
+CSS Features are tweaks to TweetDeck entirely possible through CSS, either improving the user experience or reverting
+recently made changes to the interface requested by the community.
+
+**Notice:** Please remember that BetterTweetDeck is not here to completely change up the interface of TweetDeck. If your
+ideas include overhauling the entire interface this extension is not suited for this. Consider writing an userstyle or
+your own extension!
+
+## Steps
+
+* If you have your idea, play around with it using the Inspector first, to see if it is actually possible
+* Add an option for your feature to the `css` key in [src/js/background.js](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/background.js)
+  * _Keep it short, but descriptive. If you can't describe it it 2-3 words it is probably too complex!_
+  * Use underscores for spaces!
+* Add your feature in a CSS file to [src/css/features](https://github.com/eramdam/BetterTweetDeck/blob/master/src/css/features)
+  * Name the CSS file like your feature key, but this time use dashes instead of underscores for the file name!
+  * Add the class `.btd__{your feature key}` (as written as in the options key, with underscores) in front of your CSS selectors
+* Import the created CSS file into [src/css/index.css](https://github.com/eramdam/BetterTweetDeck/blob/master/src/css/index.css)
+* Add another checkbox to make your feature selectable to [src/options/options.html](https://github.com/eramdam/BetterTweetDeck/blob/master/src/options/options.html)
+  * Find the appropriate section to add your feature, mostly it's the `General` section.
+  * Add your feature option to the end of the list with following markup:
+    ```
+      <li>
+        <input type="checkbox" name="css.{your feature key}" id="{your feature key}">
+        <label for="{your feature key}" data-lang="{your feature language key}" data-new-feat >Description of my cool new feature</label>
+      </li>
+    ```
+* Add a locale for your feature description to [src/_locales/en/messages.json](https://github.com/eramdam/BetterTweetDeck/blob/master/src/_locales/en/messages.json)
+  * Use following markup:
+    ```
+      "css_{your feature key}": { "message": "Description of my cool new feature" }
+    ```
+  * Don't forget to add your language key you added here to the `data-lang` attribute specified above!
+* Rebuild the extension, reload TweetDeck, open BetterTweetDecks options and enable your feature!

--- a/docs/extend/providers.md
+++ b/docs/extend/providers.md
@@ -1,0 +1,65 @@
+# Extend BetterTweetDeck with Thumbnail Providers
+
+Thumbnail Providers are defined services that will return media previews in TweetDeck if a URL in a 
+tweet matches an expression given by any provider.
+
+These previews are mostly embeds or images, depending on service type.
+
+## Steps
+
+* Before implementing a provider, please check if it already exists in [src/js/util/providers](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/util/providers)
+* If your provider needs to fetch data from an API, add the endpoint to the `endpoints` object in [src/js/util/thumbnails.js](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/util/thumbnails.js)
+* Create a new file for your provider using `{provider name}.js` in `src/js/util/providers`
+  * You can use the following base template for your provider:
+    ```js
+      export default function ($) {
+        return {
+          name: 'Provider',
+          setting: 'provider',
+          re: /example.com/,
+          default: true,
+          callback: url => {
+            // Add some JS code here that fetches the required data to display in the thumbnail
+            const obj = {
+              type: 'image',
+              thumbnail_url: $.getSafeURL('url'),
+              url: $.getSafeURL('url'),
+            };
+
+            return obj;
+          },
+        };
+      }
+    ```
+  * You need to return an object with a `type`, `thumbnail_url` and `url` key
+    * `type` should be one of `image`, `audio` or `video`
+    * Use `$.getSafeURL(url)` to make sure your `thumbnail_url` and `url` are in the proper format
+    * If your returned thumbnail is also an embed, you need to add it in a `html` key using an `iframe`
+  * If you need to get the endpoint for your provider, use `$.getEnpointFor('provider key')`
+  * You can use the `fetch(url)` function to get data from an API
+  * You can use `fetchPage(url)` to fetch an entire page using an XMLHttpRequest, but you need to import it first, just add this at the top of your provider file:
+    ```js
+      import { fetch as fetchPage } from '../fetchPage.js';
+    ```
+    * To properly work with the document you just loaded, you can import the `domify` module and use it like this:
+      ```js
+        import domify from 'domify';
+
+        // data is the fetchPage response
+        const el = domify(data.currentTarget.response);
+        const thumbnail = el.querySelector('[property="twitter:image"]').content;
+        const embedURL = el.querySelector('[property="twitter:player"]').content;
+      ```
+* Import your provider into [src/js/util/providers/index.js](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/util/providers/index.js):
+  ```js
+    export { default as provider } from './provider';
+  ```
+* Add your provider to the provider whitelist in [src/js/util/thumbnails.js](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/util/thumbnails.js):
+  ```js
+    const schemeWhitelist = [
+      // ...
+      Providers.provider(util),
+      // ...
+    ];
+  ```
+* Rebuild the extension, reload TweetDeck and test if your provider works!

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,18 @@
+# BetterTweetDeck Installation Guide
+
+## Simple
+
+The easiest and most practical way to install BetterTweetDeck is downloading it from App Stores:
+
+* [Chrome Web Store](https://chrome.google.com/webstore/detail/bettertweetdeck-3/micblkellenpbfapmcpcfhcoeohhnpob)
+* [Opera Addons](https://addons.opera.com/en/extensions/details/bettertweetdeck/)
+
+## For Developers
+
+If you want to contribute to the extension or just build it yourself, you need to follow these steps:
+
+* Make sure to have the latest version of [Node.js](https://nodejs.org/en/download/) installed
+* Clone this repository and open a command line in that directory
+* `npm install -g gulp && npm install` to get all required dependencies
+* `npm start` to build the project and watch for file changes
+* Open the [Chrome Extension page](chrome://extensions)/[Opera Extension page](opera://extensions), enable Developer mode and load the `dist/` folder as unpacked extension


### PR DESCRIPTION
BetterTweetDeck is missing some documentation for people that might want to help extending the client with different features, etc. pp.

This Pull Request adds the first few pieces of documentation for installation and extending with CSS-only features and thumbnail providers.

If this feature is fine as-is, it can be merged, but it can also be edited and further commits can be added for more different documentation topics, if wanted!