### PR TITLE
Add the ability to revert to old search

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -40,6 +40,7 @@
 
   "title_avatars": { "message": "Avatars & details" },
   "old_replies": { "message": "Revert to the old replies style (pre 03/30/2017)" },
+  "old_search": { "message": "Revert to the old search system (no columns for searches!)"},
   "css_round_pic": { "message": "Rounded avatars" },
   "css_bigger_emojis": { "message": "Bigger emojis in tweets" },
   "css_collapse_dms": { "message": "Collapse read direct messages" },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -50,6 +50,7 @@ const defaultSettings = {
     short_txt: false,
   },
   old_replies: false,
+  old_search: false,
   thumbnails: {},
 };
 

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -187,6 +187,10 @@ const postMessagesListeners = {
 
       TD.decider.updateForGuestId();
     }
+
+    if (settings.old_search) {
+      TD.controller.stats.setExperiments({ config: { tweetdeck_simplified_search_flow_5499: { value: 'nope' } } });
+    }
   },
 };
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -237,6 +237,10 @@
             <label for="old_replies" data-lang="old_replies" data-new-feat>Revert to the old replies style (pre 03/30/2017)</label>
           </li>
           <li>
+            <input type="checkbox" name="old_search" id="old_search">
+            <label for="old_search" data-lang="old_search" data-new-feat>Revert to the old search system (no columns for searches!)</label>
+          </li>
+          <li>
             <input type="checkbox" name="css.minimal_mode" id="minimal_mode">
             <label for="minimal_mode" data-lang="css_minimal_mode">Enable the "Minimal" mode</label>
           </li>


### PR DESCRIPTION
I genuinely hate TweetDeck.

This PR adds the ability to revert the new search (the one that opens a new column for each search) and besides that, probably a ton of other "features".

These features are hidden behind another mechanic called "experiment" which is hidden in a controller. Funnily enough, you seem to always pass ALL features back into the experiment store, so our fix to revert the search basically removes any other option.

If you want to find out what other "experiments" there are, just search for "experiment" in the bundled source code. The only use they have is basically removing them anyway.