### PR TITLE
Fix iframe/video modals

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,7 @@ module.exports = {
   },
   'globals': {
     'chrome': false,
+    'instgrm': false,
     'TD': false
   },
   'extends': 'airbnb-base',

--- a/src/css/embeds.css
+++ b/src/css/embeds.css
@@ -54,6 +54,11 @@
 
 [data-btd-provider="gyazo"],
 [data-btd-provider="bandcamp"],
+[data-btd-provider="ted"],
+[data-btd-provider="vimeo"],
+[data-btd-provider="dailymotion"],
+[data-btd-provider="youtube"],
+[data-btd-provider="imgur"],
 [data-btd-provider="spotify"] {
   .btd-embed-container.-video {
     align-items: center;

--- a/src/css/embeds.css
+++ b/src/css/embeds.css
@@ -1,0 +1,81 @@
+.noembed-embed-inner > div,
+.streamable-embed-container {
+  min-width: 750px;
+}
+
+.streamable-embed-container > iframe {
+  left: 0;
+}
+
+.btd-embed-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.btd-embed-container .btd-embed-and-links {
+  display: inline-flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+}
+
+.btd-embed-container .btd-embed-and-links img {
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.btd-embed-panel {
+  display: flex !important;
+  flex-direction: column;
+}
+
+.btd-embed-panel .med-tweet {
+  width: 100%;
+  right: 0;
+  left: 0;
+  position: relative;
+  bottom: 0;
+  margin-top: 20px;
+}
+
+.btd-embed-panel .med-tweet .item-box {
+  width: 50%;
+  margin: 0 auto;
+}
+
+.btd-embed-container.-video {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  
+  padding-top: 40px;
+}
+
+[data-btd-provider="gyazo"],
+[data-btd-provider="bandcamp"],
+[data-btd-provider="spotify"] {
+  .btd-embed-container.-video {
+    align-items: center;
+  }
+}
+
+.btd-embed-container.-video iframe {
+  max-width: 100% !important;
+  max-height: 100% !important;
+  object-fit: contain;
+}
+
+/*.btd-embed-container.-video {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+}
+
+.btd-embed-container.-video iframe,
+.btd-embed-container.-video video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}*/

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -27,6 +27,9 @@
 /* Emoji Panel */
 @import './emoji-panel.css';
 
+/* Embed/modals */
+@import './embeds.css';
+
 :root {
   /* Dark*/
   --compose-btn-bg-dark: #373839;
@@ -104,32 +107,6 @@
 .js-media-image-link,
 article video.js-media-gif {
   cursor: zoom-in !important;
-}
-
-.noembed-embed-inner > div,
-.streamable-embed-container {
-  min-width: 750px;
-}
-
-.streamable-embed-container > iframe {
-  left: 0;
-}
-
-.btd-embed-container {
-  display: flex;
-  flex-direction: column;
-}
-
-.btd-embed-container .btd-embed-and-links {
-  display: inline-flex;
-  flex: 1;
-  justify-content: center;
-  align-items: center;
-}
-
-.btd-embed-container .btd-embed-and-links img {
-  max-height: 100%;
-  object-fit: contain;
 }
 
 .tweet-dogear {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -564,6 +564,10 @@ on('BTDC_gotMediaGalleryChirpHTML', (ev, data) => {
   // setMaxDimensionsOnModalImg();
   openModal.querySelector('img, iframe').onload = (e) => e.target.setAttribute('data-btd-loaded', 'true');
 
+  if ($('[data-instgrm-version]', openModal)) {
+    sendEvent('renderInstagramEmbed');
+  }
+
   $('[rel="favorite"]', openModal)[0].addEventListener('click', () => {
     sendEvent('likeChirp', { chirpKey: chirp.id, colKey });
   });

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -23,7 +23,8 @@ const COLUMNS_MEDIA_SIZES = new Map();
  * Injecting inject.js in head before doing anything else
  */
 const scripts = [
-  chrome.extension.getURL('js/inject.js')
+  chrome.extension.getURL('js/inject.js'),
+  'https://platform.instagram.com/en_US/embeds.js',
 ];
 
 scripts.forEach(src => {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -22,9 +22,15 @@ const COLUMNS_MEDIA_SIZES = new Map();
 /**
  * Injecting inject.js in head before doing anything else
  */
-const scriptEl = document.createElement('script');
-scriptEl.src = chrome.extension.getURL('js/inject.js');
-document.head.appendChild(scriptEl);
+const scripts = [
+  chrome.extension.getURL('js/inject.js')
+];
+
+scripts.forEach(src => {
+  const el = document.createElement('script');
+  el.src = src;
+  document.head.appendChild(el);
+});
 
 sendMessage({ action: 'get_settings' }, (response) => {
   settings = response.settings;

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -27,8 +27,11 @@ sendMessage({ action: 'get_settings' }, (response) => {
   settings = response.settings;
   const scripts = [
     chrome.extension.getURL('js/inject.js'),
-    'https://platform.instagram.com/en_US/embeds.js',
   ];
+
+  if (settings.thumbnails && settings.thumbnails.instagram) {
+    scripts.push('https://platform.instagram.com/en_US/embeds.js');
+  }
 
   scripts.forEach(src => {
     const el = document.createElement('script');

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -22,19 +22,19 @@ const COLUMNS_MEDIA_SIZES = new Map();
 /**
  * Injecting inject.js in head before doing anything else
  */
-const scripts = [
-  chrome.extension.getURL('js/inject.js'),
-  'https://platform.instagram.com/en_US/embeds.js',
-];
-
-scripts.forEach(src => {
-  const el = document.createElement('script');
-  el.src = src;
-  document.head.appendChild(el);
-});
 
 sendMessage({ action: 'get_settings' }, (response) => {
   settings = response.settings;
+  const scripts = [
+    chrome.extension.getURL('js/inject.js'),
+    'https://platform.instagram.com/en_US/embeds.js',
+  ];
+
+  scripts.forEach(src => {
+    const el = document.createElement('script');
+    el.src = src;
+    document.head.appendChild(el);
+  });
 });
 
 

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -180,6 +180,9 @@ const postMessagesListeners = {
 
     chirp.retweet();
   },
+  BTDC_renderInstagramEmbed: () => {
+    instgrm.Embeds.process();
+  },
   BTDC_settingsReady: (ev, data) => {
     const { settings } = data;
     SETTINGS = settings;

--- a/src/js/util/providers/instagram.js
+++ b/src/js/util/providers/instagram.js
@@ -20,7 +20,13 @@ export default function ($) {
           return {
             type: 'video',
             thumbnail_url: $.getSafeURL(needNewThumbnail ? `${url}media/?size=t` : data.thumbnail_url),
-            html: `<iframe src="${url}embed/" width="612" height="710" style="max-height: 710px !important;" frameborder="0" scrolling="no" allowtransparency="true"></iframe>`,
+            html: `
+              <div style="width: 100%; flex: 1; display: flex; align-items: center; justify-content: center;">
+                <div style="max-width: 450px; flex: 1; max-height: 100%;" btd-instagram-embed>
+                  ${data.html}
+                </div>
+              </div>
+            `,
             url,
           };
         }

--- a/src/js/util/templates.js
+++ b/src/js/util/templates.js
@@ -15,39 +15,6 @@ const templates = {
     data-media-entity-id="{{mediaId}}"> {{#isVideo}} {{> media/video_overlay}} {{/isVideo}}  {{#imageSrc}} <img class="{{thumbClass}}" src="{{^needsSecureUrl}}{{imageSrc}}{{/needsSecureUrl}}" alt="Media preview"> {{/imageSrc}} </a> {{/isAnimatedGif}}
     {{> status/media_sensitive}}</div></div>
   `,
-  modal: `<div class="js-mediatable ovl-block is-inverted-light" btd-custom-modal>
-    <div class="s-padded">
-      <div class="js-modal-panel mdl s-full med-fullpanel"> <a href="#" class="mdl-dismiss js-dismiss mdl-dismiss-media mdl-btn-media" rel="dismiss"><i class="icon txt-size--24 icon-close"></i></a>
-        <div class="js-embeditem med-embeditem">
-          <div class="l-table">
-            <div class="l-cell">
-              <!-- Insert here  -->
-              <div class="med-tray js-mediaembed" style="opacity: 1;">
-                <div class="js-media-preview-container position-rel margin-vm">
-                  <a class="js-media-image-link block med-link media-item" href="{{imageUrl}}" rel="mediaPreview" target="_blank" data-media-entity-id="">
-                    {{^isVideo}}
-                    <img class="media-img" src="{{imageUrl}}" alt="{{AltInfo}}" data-btdsetmax>
-                    {{/isVideo}}
-                    {{#isVideo}}
-                    <div class="youtube-player -{{provider}}">
-                      {{&videoEmbed}}
-                    </div>
-                    {{/isVideo}}
-                  </a>
-                </div>
-                {{#hasGIFDownload}}
-                <a href="#" class="med-flaglink" data-btd-dl-gif rel="url" target="_blank">Download as .GIF</a>
-                {{/hasGIFDownload}}
-                <a href="{{originalUrl}}" class="med-origlink" rel="url" target="_blank">View original</a>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div id="media-gallery-tray"></div>
-        <div class="js-med-tweet med-tweet">{{&tweetEmbed}}</div>
-      </div>
-    </div>
-  </div>`,
   videoModal: `<div data-btd-provider="{{provider}}" class="js-mediatable ovl-block is-inverted-light" btd-custom-modal>
     <div class="s-padded">
       <div class="js-modal-panel mdl s-full med-fullpanel btd-embed-panel">

--- a/src/js/util/templates.js
+++ b/src/js/util/templates.js
@@ -48,17 +48,25 @@ const templates = {
       </div>
     </div>
   </div>`,
+  videoModal: `<div data-btd-provider="{{provider}}" class="js-mediatable ovl-block is-inverted-light" btd-custom-modal>
+    <div class="s-padded">
+      <div class="js-modal-panel mdl s-full med-fullpanel btd-embed-panel">
+        <a href="#" class="mdl-dismiss js-dismiss mdl-dismiss-media mdl-btn-media" rel="dismiss"><i class="icon txt-size--24 icon-close"></i></a>
+        <div class="btd-embed-container -video">
+          {{&videoEmbed}}
+        </div>
+        <div id="media-gallery-tray"></div>
+        <div class="js-med-tweet med-tweet">{{&tweetEmbed}}</div>
+      </div>
+    </div>
+  </div>`,
   imageModal: `<div class="js-mediatable ovl-block is-inverted-light" btd-custom-modal>
     <div class="s-padded">
-      <div class="js-modal-panel mdl s-full med-fullpanel"> <a href="#" class="mdl-dismiss js-dismiss mdl-dismiss-media mdl-btn-media" rel="dismiss"><i class="icon txt-size--24 icon-close"></i></a>
+      <div class="js-modal-panel mdl s-full med-fullpanel">
+        <a href="#" class="mdl-dismiss js-dismiss mdl-dismiss-media mdl-btn-media" rel="dismiss"><i class="icon txt-size--24 icon-close"></i></a>
         <div class="js-embeditem med-embeditem btd-embed-container">
           <div class="btd-embed-and-links">
-            {{^isVideo}}
             <img class="media-img" src="{{imageUrl}}" alt="{{AltInfo}}" data-btdsetmax>
-            {{/isVideo}}
-            {{#isVideo}}
-              {{&videoEmbed}}
-            {{/isVideo}}
           </div>
           
         </div>
@@ -126,7 +134,7 @@ const modalTemplate = ({ imageUrl, originalUrl, type, videoEmbed = null, provide
     imageUrl = parsed.searchParams.get('url');
   }
 
-  return Mustache.render(type === 'image' ? templates.imageModal : templates.modal, Object.assign(defaultData.modal, {
+  return Mustache.render(type === 'image' ? templates.imageModal : templates.videoModal, Object.assign(defaultData.modal, {
     imageUrl,
     videoEmbed,
     originalUrl,

--- a/src/js/util/thumbnails.js
+++ b/src/js/util/thumbnails.js
@@ -13,7 +13,7 @@ const endpoints = {
   dribbble: 'https://api.dribbble.com/v1/shots/',
   noembed: 'https://noembed.com/embed?nowrap=on&url=',
   imgur: 'https://api.imgur.com/3/',
-  instagram: 'https://api.instagram.com/oembed?url=',
+  instagram: 'https://api.instagram.com/oembed?omitscript=true&url=',
   twitch: 'https://api.twitch.tv/kraken/',
   giphy: 'https://giphy.com/services/oembed?url=',
   pixiv: 'http://embed.pixiv.net/embed_json.php?callback=callback&size=medium&id=',


### PR DESCRIPTION
Embeds for anything except images are broken right now in the sense that they either display at the wrong size (https://github.com/eramdam/BetterTweetDeck/issues/138) or just doesn't even display correctly (like Instagram).

This PR fixes that by replacing the modal HTML with a custom one that uses Flexbox to automatically center and size everything correctly.