### PR TITLE
Fix `btd-settings-btn` markup and integration

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -97,12 +97,12 @@
   display: none;
 }
 
-.btd-settings-btn .icon {
-  color: #009cf0;
+.column-navigator-overflow {
+  bottom: 267px !important;
 }
 
-.column-navigator-overflow {
-  bottom: 260px !important;
+.app-navigator .with-nav-border-t:not(:first-of-type)::before {
+  display: none;
 }
 
 .js-add-emojis .btd-emoji-icon::before {

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -608,11 +608,11 @@ on('BTDC_ready', () => {
 
   const settingsURL = chrome.extension.getURL('options/options.html');
   const settingsBtn = `
-    <a class="btd-settings-btn js-header-action link-clean cf app-nav-link padding-hl txt-size--16 data-title="BTD Settings" style="margin-bottom: 6px;">
+    <a class="btd-settings-btn js-header-action link-clean cf app-nav-link padding-h--10 with-nav-border-t" data-title="BTD Settings" style="margin-bottom: 6px;">
       <div class="obj-left margin-l--2">
         <i class="icon icon-sliders icon-medium"></i>
       </div>
-      <div class="nbfc padding-ts hide-condensed">BTD Settings</div>
+      <div class="nbfc padding-ts hide-condensed txt-size--16">BTD Settings</div>
     </a>
   `;
   $('nav.app-navigator')[0].insertAdjacentHTML('afterbegin', settingsBtn);

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -608,7 +608,7 @@ on('BTDC_ready', () => {
 
   const settingsURL = chrome.extension.getURL('options/options.html');
   const settingsBtn = `
-    <a class="btd-settings-btn js-header-action link-clean cf app-nav-link padding-h--10 with-nav-border-t" data-title="BTD Settings" style="margin-bottom: 6px;">
+    <a class="btd-settings-btn js-header-action link-clean cf app-nav-link padding-h--10 with-nav-border-t" data-title="BTD Settings">
       <div class="obj-left margin-l--2">
         <i class="icon icon-sliders icon-medium"></i>
       </div>


### PR DESCRIPTION
Some little fixes for the `.btd-settings-btn`:
* Reflect TD CSS classes changes
* Fix attribute typo (missing closing `"` for `class` attribute)
* Better button position
* Fix the nav top bar position (with `.with-nav-border-t`)
* Better `.column-navigator-overflow` limits

---
Before|After
---|---
![image](https://user-images.githubusercontent.com/846943/27511975-803c204a-5932-11e7-93e7-7406eed5e439.png)|![image](https://user-images.githubusercontent.com/846943/27511967-64d16cd4-5932-11e7-9d05-557ecab8e695.png)
