### PR TITLE
Allowed downloading quoted tweet media in the popout modal.

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -82,11 +82,11 @@ const getChirpFromElement = (element) => {
 
   let col = chirp.closest('[data-column]');
   if (!col) {
-    col = document.querySelector(`[data-column] [data-key="${chirpKey}"]`);
-    if (!col || !col.parentNode) {
-      throw new Error('Chirp has no column');
+    const chirpElm = document.querySelector(`[data-column] [data-key="${chirpKey}"]`);
+    if (!chirpElm) {
+      throw new Error('Could not locate chirp in any column.');
     } else {
-      col = col.parentNode;
+      col = chirpElm.closest('[data-column]');
     }
   }
 


### PR DESCRIPTION
This does not let you download media from tweets that contain quotes in a timeline, because on the mustache `{{#tweet.entities.media.length}}` we can't check `{{#tweet.quotedTweet}}` as well. This only works for retweets because retweets also populate `entities.media`. For quotes, only `entities.urls` are populated but this isn't reliable enough to use compared to `quotedTweet`.

I wouldn't know a good way to go about this without hacking things onto `TD.services.TwitterStatus`.