### PR TITLE
Added hiding columns from the column header.

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -58,9 +58,9 @@
   "flash_tweets": { "message": "Make tweets flash in:" },
   "flash_tweets_mentions": { "message": "Mentions columns" },
   "flash_tweets_all": { "message": "Every column" },
-  
+
   "update_title_on_notifications": { "message": "Display an unread tweets/DMs indicator in TweetDeck's tab's title." },
-  
+
   "share_request": { "message": "Request tabs reading permissions" },
   "share_granted": { "message": "Permissions granted" },
   "shared_btd_h1": { "message": "Sharing" },
@@ -85,7 +85,9 @@
   "custom_width_columns": { "message": "Apply a custom width for columns:" },
   "custom_width_size": { "message": "Width (any valid CSS value)" },
   "css_warning": { "message": "Be sure of what you're typing here, don't paste something you don't understand!)" },
-  
+
+  "collapse_columns": { "message": "Add a column header button to collapse and uncollapse columns."},
+
   "regex_filter": { "message": "Enable regular expression support in Mute filters"},
   "regex_filter_notice_text": { "message": "Due to the way TweetDeck's filtering works, expressions are NOT case sensitive!" },
 

--- a/src/css/features/collapse-columns.css
+++ b/src/css/features/collapse-columns.css
@@ -9,6 +9,9 @@ section.btd-column-collapsed {
     transform: rotate(90deg);
     width: 100vh;
     top: -50px;
+
+    display: flex;
+    flex-direction: row;
   }
 
   i.column-type-icon {
@@ -17,6 +20,27 @@ section.btd-column-collapsed {
     position: relative;
     left: 12px;
     bottom: 0;
+
+    order: 1;
+  }
+
+  .column-title {
+    order: 2;
+    margin-left: 4px;
+  }
+
+  ul.btd-column-buttons {
+    order: 0;
+    position: relative;
+    margin-left: 10px;
+  }
+
+  &.column-type-message ul.btd-column-buttons {
+    flex-direction: row-reverse;
+  }
+
+  &.column-type-message ul.btd-column-buttons li:nth-child(3) {
+    order: 1;
   }
 
   i.column-type-icon:before {
@@ -44,12 +68,13 @@ ul.btd-column-buttons {
   right: 5px;
   bottom: -1px;
   padding: 0 4px;
+  display: flex;
+  flex-direction: row;
 
   li {
     /* undo the .column-header-link styles for the children */
     position: relative;
     margin: 0;
-    float: left;
 
     a.column-header-link {
       margin: 0;

--- a/src/css/features/collapse-columns.css
+++ b/src/css/features/collapse-columns.css
@@ -9,7 +9,6 @@ section.btd-column-collapsed {
     transform: rotate(90deg);
     width: 100vh;
     top: -50px;
-
     display: flex;
     flex-direction: row;
   }
@@ -20,7 +19,6 @@ section.btd-column-collapsed {
     position: relative;
     left: 12px;
     bottom: 0;
-
     order: 1;
   }
 
@@ -43,13 +41,13 @@ section.btd-column-collapsed {
     order: 1;
   }
 
-  i.column-type-icon:before {
+  i.column-type-icon::before {
     position: relative;
     top: -14px;
   }
 
   /* uiColumnTitleRefreshed forces us to change this class (mustache recalc), or we could cheat */
-  .icon-minus:before {
+  .icon-minus::before {
     content: "\f183";
   }
 

--- a/src/css/features/collapse-columns.css
+++ b/src/css/features/collapse-columns.css
@@ -1,0 +1,66 @@
+/* collapsed column states */
+section.btd-column-collapsed {
+  &.column {
+    width: 52px !important;
+  }
+
+  .js-column-header {
+    transform-origin: 0 100%;
+    transform: rotate(90deg);
+    width: 100vh;
+    top: -50px;
+  }
+
+  i.column-type-icon {
+    transform-origin: 50% 100%;
+    transform: rotate(-90deg);
+    position: relative;
+    left: 12px;
+    bottom: 0;
+  }
+
+  i.column-type-icon:before {
+    position: relative;
+    top: -14px;
+  }
+
+  /* uiColumnTitleRefreshed forces us to change this class (mustache recalc), or we could cheat */
+  .icon-minus:before {
+    content: "\f183";
+  }
+
+  .js-column-content,
+  .js-add-to-customtimeline {
+    display: none;
+  }
+}
+
+ul.btd-column-buttons {
+  /* move .column-header-link styles to here */
+  float: right;
+  width: auto;
+  margin: 0;
+  position: absolute;
+  right: 5px;
+  bottom: -1px;
+  padding: 0 4px;
+
+  li {
+    /* undo the .column-header-link styles for the children */
+    position: relative;
+    margin: 0;
+    float: left;
+
+    a.column-header-link {
+      margin: 0;
+      top: 0;
+      right: 0;
+      position: inherit;
+      display: block;
+
+      i {
+        vertical-align: text-bottom;
+      }
+    }
+  }
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -217,6 +217,11 @@ section.btd-column-collapsed.column {
   width: 52px !important;
 }
 
+/* uiColumnTitleRefreshed forces us to change this class (mustache recalc), or we could cheat */
+.btd-column-collapsed .icon-minus:before {
+  content: "\f183" !important;
+}
+
 .btd-column-collapsed .js-column-content,
 .btd-column-collapsed .js-add-to-customtimeline {
   display: none !important;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -12,6 +12,7 @@
 @import './features/hide-context.css';
 @import './features/hide-scrollbars.css';
 @import './features/hide-url-thumb.css';
+@import './features/collapse-columns.css';
 @import './features/no-col-icns.css';
 @import './features/no-bg-modal.css';
 @import './features/no-play-btn.css';
@@ -185,73 +186,6 @@ body :matches(.tweet-avatar, .prf-img, .avatar, .compose-account) {
 
 .icon-download::before {
   content: "\F186";
-}
-
-/* collapsed column states */
-.btd-column-collapsed .js-column-header {
-  transform-origin: 0% 100%;
-  transform: rotate(90deg) !important;
-  width: 100vh !important;
-  top: -50px !important;
-}
-
-.btd-column-collapsed .js-action-header-button {
-  transform-origin: 50% 50%;
-  transform: rotate(-90deg) !important;
-}
-
-.btd-column-collapsed i.column-type-icon {
-  transform-origin: 50% 100%;
-  transform: rotate(-90deg) !important;
-  position: relative !important;
-  left: 12px !important;
-  bottom: 0px !important;
-}
-
-.btd-column-collapsed i.column-type-icon:before {
-  position: relative !important;
-  top: -14px !important;
-}
-
-section.btd-column-collapsed.column {
-  width: 52px !important;
-}
-
-/* uiColumnTitleRefreshed forces us to change this class (mustache recalc), or we could cheat */
-.btd-column-collapsed .icon-minus:before {
-  content: "\f183" !important;
-}
-
-.btd-column-collapsed .js-column-content,
-.btd-column-collapsed .js-add-to-customtimeline {
-  display: none !important;
-}
-
-.btd-column-buttons-better {
-  /* move .column-header-link styles to here */
-  float: right;
-  width: auto;
-  margin: 0px;
-  position: absolute;
-  top: 5px;
-  right: 5px;
-  bottom: -1px;
-  padding: 0 4px;
-}
-
-.btd-column-buttons-better li {
-  /* undo the .column-header-link styles for the children */
-  position: relative !important;
-  margin: 0 !important;
-  float: left !important;
-}
-
-.btd-column-buttons-better li a.column-header-link {
-  margin: 0 !important;
-  top: 0px !important;
-  right: 0px !important;
-  position: inherit !important;
-  display: block !important;
 }
 
 .tweet-detail-actions.tweet-detail-actions {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -187,6 +187,33 @@ body :matches(.tweet-avatar, .prf-img, .avatar, .compose-account) {
   content: "\F186";
 }
 
+.btd-column-buttons-better {
+  /* move .column-header-link styles to here */
+  float: right;
+  width: auto;
+  margin: 0px;
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  bottom: -1px;
+  padding: 0 4px;
+}
+
+.btd-column-buttons-better li {
+  /* undo the .column-header-link styles for the children */
+  position: relative !important;
+  margin: 0 !important;
+  float: left !important;
+}
+
+.btd-column-buttons-better li a.column-header-link {
+  margin: 0 !important;
+  top: 0px !important;
+  right: 0px !important;
+  position: inherit !important;
+  display: block !important;
+}
+
 .tweet-detail-actions.tweet-detail-actions {
   display: flex;
   padding-bottom: 8px;

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -187,6 +187,41 @@ body :matches(.tweet-avatar, .prf-img, .avatar, .compose-account) {
   content: "\F186";
 }
 
+/* collapsed column states */
+.btd-column-collapsed .js-column-header {
+  transform-origin: 0% 100%;
+  transform: rotate(90deg) !important;
+  width: 100vh !important;
+  top: -50px !important;
+}
+
+.btd-column-collapsed .js-action-header-button {
+  transform-origin: 50% 50%;
+  transform: rotate(-90deg) !important;
+}
+
+.btd-column-collapsed i.column-type-icon {
+  transform-origin: 50% 100%;
+  transform: rotate(-90deg) !important;
+  position: relative !important;
+  left: 12px !important;
+  bottom: 0px !important;
+}
+
+.btd-column-collapsed i.column-type-icon:before {
+  position: relative !important;
+  top: -14px !important;
+}
+
+section.btd-column-collapsed.column {
+  width: 52px !important;
+}
+
+.btd-column-collapsed .js-column-content,
+.btd-column-collapsed .js-add-to-customtimeline {
+  display: none !important;
+}
+
 .btd-column-buttons-better {
   /* move .column-header-link styles to here */
   float: right;

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -25,6 +25,7 @@ const defaultSettings = {
     size: '250px',
     enabled: false,
   },
+  collapse_columns: false,
   css: {
     round_pic: true,
     bigger_emojis: true,

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -148,7 +148,7 @@ function tweakClassesFromVisualSettings() {
 
     styleTag.type = 'text/css';
     styleTag.appendChild(document.createTextNode(`
-      body.btd__custom_column_size .column {
+      .column {
         width: ${safeValue} !important;
       }
     `));

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -39,6 +39,7 @@ scripts.forEach((src) => {
 
 sendMessage({ action: 'get_settings' }, (response) => {
   settings = response.settings;
+  sendEvent('settingsReady', { settings });
   const getFontFile = format => chrome.extension.getURL(`fonts/tweetdeck-regular-webfont-old.${format}`);
 
   const style = document.createElement('style');
@@ -509,7 +510,6 @@ window.addEventListener('resize', setMaxDimensionsOnModalImg);
 // Prepare to know when TD is ready
 on('BTDC_ready', () => {
   tweakClassesFromVisualSettings();
-  sendEvent('settingsReady', { settings });
   // Refresh timestamps once and then set the interval
   refreshTimestamps();
   setInterval(refreshTimestamps, TIMESTAMP_INTERVAL);

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -4,6 +4,16 @@ import Clipboard from 'clipboard';
 import Log from './util/logger';
 import UsernamesTemplates from './util/username_templates';
 
+TD.mustaches['column/column_header.mustache'] = TD.mustaches['column/column_header.mustache']
+  // wrap everyting with an ul
+  .replace('{{/withEditableTitle}}', '{{/withEditableTitle}} <ul class="btd-column-buttons-better">')
+  .replace('{{/isTemporary}} </header>', '{{/isTemporary}} </ul> </header>')
+  // shove in buttons we care about
+  .replace('{{/withMarkAllRead}}  {{^isTemporary}}', '{{/withMarkAllRead}}  {{^isTemporary}} <a class="js-action-header-button column-header-link btd-column-minimize-link" href="#" data-action="minimize-column"> <i class="icon icon-minus"></i> </a> ')
+  // wrap all the <a>s with <li>s
+  .replace(/<\/i> <\/a>/g, '</i> </a> </li>')
+  .replace(/<a class="js-action-header-button/g, '<li class="btd-column-buttons-better"> <a class="js-action-header-button');
+
 let SETTINGS;
 
 const deciderOverride = {
@@ -650,6 +660,29 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
   if (!user.following) {
     user.follow(chirp.account, null, null, true);
   }
+});
+
+$(document).on('click', '#column-navigator .column-nav-item', (ev) => {
+  ev.preventDefault();
+
+  const thisNav = $(ev.target.closest('li[data-column]'));
+  const columnKey = thisNav.data('column');
+
+  if (thisNav.data('btd-column-minimized')) {
+    thisNav.data('btd-column-minimized', false);
+    $(`section.column[data-column="${columnKey}"]`).show();
+  }
+});
+
+$(document).on('click', '.column-panel header .column-header-link[data-action="minimize-column"]', (ev) => {
+  ev.preventDefault();
+
+  const thisColumn = ev.target.closest('[data-column]');
+  const columnKey = thisColumn.getAttribute('data-column');
+  const columnNav = $(`#column-navigator .column-nav-item[data-column="${columnKey}"]`);
+
+  columnNav.data('btd-column-minimized', true);
+  $(thisColumn).hide();
 });
 
 $('body').on('click', '[data-btd-action="download-media"]', (ev) => {

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -722,6 +722,7 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
             delete dataBoy[this._parent.model.privateState.apiid];
             this._isCollapsed = false;
             window.localStorage.setItem('btd_collapsed_columns', JSON.stringify(dataBoy));
+            TD.controller.columnManager.showColumn(columnKey);
           }
         },
         toggleCollapse(state = false) {

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -665,24 +665,27 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
 $(document).on('click', '#column-navigator .column-nav-item', (ev) => {
   ev.preventDefault();
 
+  const dataBoy = $('nav#column-navigator').parent();
+
   const thisNav = $(ev.target.closest('li[data-column]'));
   const columnKey = thisNav.data('column');
 
-  if (thisNav.data('btd-column-minimized')) {
-    thisNav.data('btd-column-minimized', false);
-    $(`section.column[data-column="${columnKey}"]`).show();
+  if (dataBoy.data(`minimized-columns-${columnKey}`)) {
+    dataBoy.data(`minimized-columns-${columnKey}`, false);
+    $(`section.column[data-column="${columnKey}"]`).removeClass('btd-column-collapsed');
   }
 });
 
 $(document).on('click', '.column-panel header .column-header-link[data-action="minimize-column"]', (ev) => {
   ev.preventDefault();
 
+  const dataBoy = $('nav#column-navigator').parent();
+
   const thisColumn = ev.target.closest('[data-column]');
   const columnKey = thisColumn.getAttribute('data-column');
-  const columnNav = $(`#column-navigator .column-nav-item[data-column="${columnKey}"]`);
 
-  columnNav.data('btd-column-minimized', true);
-  $(thisColumn).hide();
+  dataBoy.data(`minimized-columns-${columnKey}`, true);
+  $(thisColumn).addClass('btd-column-collapsed');
 });
 
 $('body').on('click', '[data-btd-action="download-media"]', (ev) => {

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -695,7 +695,7 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
           return this._isCollapsed || false;
         },
         collapse() {
-          if (SETTINGS.collapse_columns) {
+          if (!SETTINGS.collapse_columns) {
             return;
           }
           const dataBoy = JSON.parse(window.localStorage.getItem('btd_collapsed_columns'));
@@ -709,7 +709,7 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
           window.localStorage.setItem('btd_collapsed_columns', JSON.stringify(dataBoy));
         },
         uncollapse() {
-          if (SETTINGS.collapse_columns) {
+          if (!SETTINGS.collapse_columns) {
             return;
           }
           const dataBoy = JSON.parse(window.localStorage.getItem('btd_collapsed_columns'));
@@ -725,9 +725,12 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
           }
         },
         toggleCollapse(state = false) {
+          Log('wat do');
           if (this._isCollapsed || state) {
+            Log('uncollapse');
             this.uncollapse();
           } else {
+            Log('collapse');
             this.collapse();
           }
         },
@@ -736,9 +739,9 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
   };
 })(TD.vo.Column);
 
-$(document).on('click', '#column-navigator .column-nav-item', (ev) => {
+$('body').on('click', '#column-navigator .column-nav-item', (ev) => {
   ev.preventDefault();
-  if (SETTINGS.collapse_columns) {
+  if (!SETTINGS.collapse_columns) {
     return;
   }
 
@@ -747,9 +750,9 @@ $(document).on('click', '#column-navigator .column-nav-item', (ev) => {
   TD.controller.columnManager.get(columnKey)._btd.uncollapse();
 });
 
-$(document).on('click', '.column-panel header.column-header .btd-toggle-collapse-column-link', (ev) => {
+$('body').on('click', '.column-panel header.column-header .btd-toggle-collapse-column-link', (ev) => {
   ev.preventDefault();
-  if (SETTINGS.collapse_columns) {
+  if (!SETTINGS.collapse_columns) {
     return;
   }
 

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -684,8 +684,8 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
 
 ((originalColumn) => {
   TD.vo.Column = class Column extends originalColumn {
-    constructor(executor) {
-      super(executor);
+    constructor(...args) {
+      super(...args);
 
       const _parent = this;
       this._btd = {

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -725,12 +725,9 @@ $('body').on('click', '.tweet-action[rel="favorite"], .tweet-detail-action[rel="
           }
         },
         toggleCollapse(state = false) {
-          Log('wat do');
           if (this._isCollapsed || state) {
-            Log('uncollapse');
             this.uncollapse();
           } else {
-            Log('collapse');
             this.collapse();
           }
         },
@@ -750,7 +747,7 @@ $('body').on('click', '#column-navigator .column-nav-item', (ev) => {
   TD.controller.columnManager.get(columnKey)._btd.uncollapse();
 });
 
-$('body').on('click', '.column-panel header.column-header .btd-toggle-collapse-column-link', (ev) => {
+$('body').on('mousedown', '.column-panel header.column-header .btd-toggle-collapse-column-link', (ev) => {
   ev.preventDefault();
   if (!SETTINGS.collapse_columns) {
     return;

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -749,7 +749,7 @@ $('body').on('click', '#column-navigator .column-nav-item', (ev) => {
 
 $('body').on('mousedown', '.column-panel header.column-header .btd-toggle-collapse-column-link', (ev) => {
   ev.preventDefault();
-  if (!SETTINGS.collapse_columns) {
+  if (!SETTINGS.collapse_columns || ev.which !== 1) {
     return;
   }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -251,21 +251,21 @@
       </div>
       <button class="save-button" disabled data-lang="save_no">No changes</button>
     </section>
-    
+
     <section class="content-block" id="share">
       <h2 class="section-title" data-lang="shared_btd_h1">Sharing</h2>
-      
+
       <div class="settings-section" data-require-permission>
         <p data-lang="share_btd_p1" data-hidden-firefox>In order to use the "Share on TweetDeck" feature, you'll need to approve certain permissions which you can do so by clicking below</p>
-        
+
         <p data-hidden-firefox>
           <button class="plain-button" data-lang="share_request" data-ask-permissions>Request tabs reading permissions</button>
         </p>
 
         <p data-lang="share_btd_p2">Better TweetDeck can <strong>NOT</strong> read or track the contents of any open tabs.</p>
-        
+
         <p data-lang="share_btd_p3">Feel free to read <a href="https://developer.chrome.com/extensions/tabs">Chrome's documentation</a> about this permission for more details.</p>
-        
+
         <p><strong data-lang="share_btd_p4">Any modification on this page will be applied after a browser restart</strong></p>
 
         <ul>
@@ -341,6 +341,10 @@
               </li>
             </ul>
           </li>
+          <li data-setting-name="collapse_columns">
+            <input type="checkbox" name="collapse_columns" id="collapse_columns">
+            <label for="collapse_columns" data-lang="collapse_columns" data-new-feat>Add a column header button to collapse and uncollapse columns.</label>
+          </li>
         </ul>
       </div>
       <button class="save-button" disabled data-lang="save_no">No changes</button>
@@ -395,7 +399,7 @@
       <h2 class="section-title">Donate</h2>
       <div class="settings-section">
         <h5>If you're in the US, I'd rather have you donate to one of those charities instead.</h5>
-        
+
         <ul>
           <li><a href="https://secure3.convio.net/cfrr/site/Donation2;jsessionid=97A4C7A9488B5DDF3450546DE1123DB2.app347a?1380.donation=form1&df_id=1380&web&_ga=1.145398384.513337705.1476995534">Center for Reproductive Rights</a></li>
           <li><a href="https://www.lambdalegal.org/donate">Lambda Legal</a></li>


### PR DESCRIPTION
Hide a column by clicking on `-` a lot.
Restore a column by clicking on it in the left column navigator.

notes:
 * needs more work
 * keyboard navigation `1-9` seems to work weirdly.
  * if you minimize a column in the front, pressing `1` will take you
    to the _new_ first available column
  * if you minimize a column in the 4th position then it will
    absorb keypresses as if it is still there
 * the column heads show numbers, these are from CSS, therefore hiding
   a column makes the styles skip numbers making it appear as if they
   do not exist anywhere but the left navigation
 * lots of styles could probably be shaved out but i'm bad at everything

not tested columns:

 * any 'temporary' column (whatever those are)
 * columns with long titles and/or usernames
 * searches / trending / editable column titles

tested columns:

 * home
 * collections
 * notifications
 * messages / all messages
 * likes
 * mentions / all mentions
 * followers
 * activity
 * scheduled (seems good?)