### PR TITLE
only run eslint on src, tools, config, and gulpfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "release:firefox": "npm run build:firefox:prod && npm run pack:firefox && rimraf artifacts/dist-firefox.zip",
     "release:chrome": "npm run build:chrome:prod && cross-env NODE_ENV=prod npm run pack:chrome",
     "run:firefox": "web-ext run -s dist",
-    "lint": "eslint . && stylelint src/**/*.css",
+    "lint": "eslint \"src/**/*.js\" \"tools/**/*.js\" \"config/**/*.js\" gulpfile.babel.js && stylelint \"src/**/*.css\"",
     "test": "npm run lint && npm run release",
     "update_emojis": "node tools/update_emojis.js",
     "prepush": "npm run lint"


### PR DESCRIPTION
stop trying to pick fights with javascript we don't even use

the reason I used quotes was because we wanna use [node style globbing](https://eslint.org/docs/user-guide/command-line-interface) on windows