### PR TITLE
allowed the extension_ids array to be read properly

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -1,20 +1,6 @@
 module.exports = {
   FirefoxId: '',
   opera_key: '',
-  extension_ids: {
-    chrome: {
-      release: '',
-      beta: '',
-    },
-    firefox: {
-      release: '',
-      beta: '',
-    },
-    opera: {
-      release: '',
-      beta: '',
-    },
-  },
   Client: {
     debug: false,
     remote_inst: true,
@@ -23,6 +9,20 @@ module.exports = {
       imgur: '',
       twitch: '',
       tinami: '',
+    },
+    extension_ids: {
+      chrome: {
+        release: '',
+        beta: '',
+      },
+      firefox: {
+        release: '',
+        beta: '',
+      },
+      opera: {
+        release: '',
+        beta: '',
+      },
     },
   },
 };

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -547,7 +547,7 @@ on('BTDC_ready', () => {
   // Tell any potential versions of BTD that they are not alone, and alert the user if they respond.
   const browser = BHelper.getBrowser();
   if (browser) {
-    const extensions = config.get(`extension_ids.${browser}`);
+    const extensions = config.get(`Client.extension_ids.${browser}`);
     Object.values(extensions || {}).forEach((extensionID) => {
       chrome.runtime.sendMessage(
         extensionID, { action: 'version', key: BHelper.getVersion() }, {},


### PR DESCRIPTION
config-browserify wasn't letting the client files read things right and it was confusing and made me upset

***this should be merged in before the beta program goes live.**

fortunately, the existing beta builds that are based off the initial set of code will respond properly

the current beta build (3.4.5) responds to the version check fine, so you can test this code against the current beta build