### PR TITLE
two hundred and eighty characters

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -108,7 +108,7 @@
   "ctrl_changes_interactions__mode__dialog": { "message": "follow dialog"},
 
   "two_eight_zero_chars": { "message": "Switch the characters limit to 280 <strong>EXPERIMENTAL, USE AT YOUR OWN RISK</strong>"},
-  "two_eight_zero_note": { "message": "This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters."},
+  "two_eight_zero_note": { "message": "This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters. The scheduler still works, but not with tweets over 140 characters due to API restrictions."},
 
   "btd_thx": { "message": "Thanks for installing Better TweetDeck!" },
   "btd_get_started": { "message": "Let's get started!" },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -107,6 +107,9 @@
   "ctrl_changes_interactions__mode__owner": { "message": "column's owner"},
   "ctrl_changes_interactions__mode__dialog": { "message": "follow dialog"},
 
+  "two_eight_zero_chars": { "message": "Switch the characters limit to 280 <strong>EXPERIMENTAL, USE AT YOUR OWN RISK</strong>"},
+  "two_eight_zero_note": { "message": "This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters."},
+
   "btd_thx": { "message": "Thanks for installing Better TweetDeck!" },
   "btd_get_started": { "message": "Let's get started!" },
   "btd_whatsBTD": { "message": "Better TweetDeck is made to improve your experience on <a href='https://tweetdeck.twitter.com'>tweetdeck.twitter.com</a>!" },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -26,6 +26,7 @@ const defaultSettings = {
     size: '250px',
     enabled: false,
   },
+  two_eight_zero_chars: false,
   clear_column_action: false,
   collapse_columns: false,
   collapse_columns_pause: true,

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -655,6 +655,55 @@ $(document).keydown((ev) => {
   }
 });
 
+/*
+  This snippet is essentially the same as being in the Twitter longer tweets test, for TweetDeck
+  The Tweet length counter is fixed by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140
+  instead of 280 in the counter but going over 140 will give you another set of 140 characters.
+
+  modified, from: https://gist.github.com/Zemnmez/ffb5449d873d5407c7172534b762ae46/
+*/
+let moreTweetsEnabled = false;
+
+const twoEightZero = () => {
+  if (SETTINGS.two_eight_zero_chars && !moreTweetsEnabled) {
+    TD.services.TwitterClient.prototype.makeTwitterCall = function (e, t, i, n, s, r, o) {
+      s = s || function () {};
+      r = r || function () {};
+
+      const a = this.request(e, {
+        method: i,
+        params: Object.assign(t, {
+          weighted_character_count: !0,
+        }),
+        processor: n,
+        feedType: o,
+      });
+      a.addCallbacks((_e) => {
+        s(_e.data);
+      }, (_e) => {
+        r(_e.req, '', _e.msg, _e.req.errors);
+      });
+      return a;
+    };
+    window.twttrTxt = Object.assign({}, window.twttr.txt, {
+      isInvalidTweet() {
+        return !1;
+      },
+      getTweetLength(x) {
+        // eslint-disable-next-line prefer-rest-params
+        x = window.twttr.txt.getTweetLength.apply(this, arguments);
+        return x <= 140 ? x : x - 140;
+      },
+    });
+    moreTweetsEnabled = true;
+  }
+};
+
+if (SETTINGS.two_eight_zero_chars) {
+  $(document).one('uiDockedComposeTweet', twoEightZero);
+  $(document).one('uiComposeTweet', twoEightZero);
+}
+
 $(document).on('openBtdSettings', (ev, data) => {
   window.open(data.url);
 });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -246,7 +246,7 @@
           <li data-setting-name="two_eight_zero_chars">
             <input type="checkbox" name="two_eight_zero_chars" id="two_eight_zero_chars">
             <label for="two_eight_zero_chars" data-lang="two_eight_zero_chars" data-new-feat>Switch the characters limit to 280 <strong>EXPERIMENTAL, USE AT YOUR OWN RISK</strong></label><br>
-            <small data-lang="two_eight_zero_note">This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters.</small>
+            <small data-lang="two_eight_zero_note">This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters.  The scheduler still works, but not with tweets over 140 characters due to API restrictions.</small>
           </li>
         </ul>
       </div>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -243,6 +243,11 @@
             <input type="checkbox" name="ctrl_changes_interactions.enabled" id="ctrl_changes_interactions.enabled" data-ghost>
             <label for="ctrl_changes_interactions.enabled" data-lang="ctrl_changes_interactions__enabled">Holding <kbd>ctrl</kbd> while clicking: favorite / retweet / download / hotlink will allow you to follow from the</label> <select name="ctrl_changes_interactions.mode" id="ctrl_changes_interactions.mode" disabled data-new-feat><option value="owner" data-lang="ctrl_changes_interactions__mode__owner">column's owner</option><option value="prompt" data-lang="ctrl_changes_interactions__mode__dialog">follow dialog</option></select></label>
           </li>
+          <li data-setting-name="two_eight_zero_chars">
+            <input type="checkbox" name="two_eight_zero_chars" id="two_eight_zero_chars">
+            <label for="two_eight_zero_chars" data-lang="two_eight_zero_chars" data-new-feat>Switch the characters limit to 280 <strong>EXPERIMENTAL, USE AT YOUR OWN RISK</strong></label><br>
+            <small data-lang="two_eight_zero_note">This works by tricking TweetDeck into counting up to 140 characters, twice, so you'll see 140 instead of 280 in the counter but going over 140 will give you another set of 140 characters.</small>
+          </li>
         </ul>
       </div>
 


### PR DESCRIPTION
modifications from source:
 - fixed composer remaining numbers if at or above 280
 - kept as close to the original source as eslint would allow
 - fires with 'one', only does that if setting is enabled

notes:
 - unnamed functions break if arrowed
 - no-rest-args breaks if spread operator used