### PR TITLE
makes 280 char wrap gooder

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -669,7 +669,7 @@ const twoEightZero = () => {
   if (SETTINGS.two_eight_zero_chars && !moreTweetsEnabled) {
     TD.services.TwitterClient.prototype.OGTwitterCall = TD.services.TwitterClient.prototype.makeTwitterCall;
     TD.services.TwitterClient.prototype.makeTwitterCall = function makeTwitterCall(path, t, method, n, s, r, o) {
-      if (path.endsWith('dm/new.json') || path.endsWith('statuses/update.json')) {
+      if (path.endsWith('statuses/update.json')) {
         s = s || noop;
         r = r || noop;
 


### PR DESCRIPTION
the reason twittercall fails was because `this` was messed up,
wrapping it still obscured `this`.

this code also only listens for relevant API endpoints, as opposed to
excluding purely retweets for the sake of safety.