### PR TITLE
Add support for completing emoji shortcodes with tabulator key

### DIFF
--- a/src/js/util/emojis.js
+++ b/src/js/util/emojis.js
@@ -294,6 +294,7 @@ function keypressHandler(event) {
       moveSelection(event, -1);
       break;
 
+    case 'tab':
     case 'enter':
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
This PR adds support for completing shortcodes of emoji with tab (instead of just with the enter key).

**Example:**
`:smil` -> *TAB Press* -> 😃

Most Platforms (like WhatsApp and Telegram) support completing shortcodes with TAB, since it's easier when writing to reach for the tab key instead of the enter key. When I write a tweet and use a shortcode in it I automatically hit TAB for completing the emoji (because of my habits of WhatsApp and Telegram) which currently leads to a focus change onto the send button. That's a bit annoying.