### PR TITLE
:wrench: remove formatting guide from name

### DIFF
--- a/src/js/util/ame.js
+++ b/src/js/util/ame.js
@@ -52,7 +52,7 @@ export default function () {
       display: {
         global: true,
       },
-      name: 'Keyword from User (user|keyword)',
+      name: 'Keyword from User',
       descriptor: 'user|keyword: ',
       placeholder: 'e.g. tweetdeck|feature',
       function(t, e) {


### PR DESCRIPTION
Small PR to remove the formatting help for the user|keyword filter.

The placeholder explains it enough, I guess.