### PR TITLE
Add locale texts for the "Re-enable Dark Theme" setting and update Japanese

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -77,6 +77,8 @@
   "thumbnails_from": { "message": "Display thumbnails from:" },
 
   "css_minimal_mode": { "message": "Enable the 'Minimal' theme" },
+  "css_og_dark_theme": { "message": "Re-enable the Dark theme (pre February 2018)" },
+  "css_experimental_warning": { "message": "This is experimental and can break at any point!" },
   "css_no_play_btn": { "message": "Hide the play button on video thumbnails" },
   "css_hide_url_thumb": { "message": "Hide the link related to thumbnails in tweets (à la Twitter iOS/Android)" },
   "css_no_col_icns": { "message": "Hide icons in columns headers" },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -77,6 +77,8 @@
   "thumbnails_from": { "message": "次のサービスのサムネイル画像を表示する" },
 
   "css_minimal_mode": { "message": "「ミニマル」モードを有効にする" },
+  "css_og_dark_theme": { "message": "Dark テーマを以前のスタイルに元に戻す (2018年2月より前のスタイル)" },
+  "css_experimental_warning": { "message": "これは実験的な機能です！ 将来の更新で壊れてしまう可能性があります。" },
   "css_no_play_btn": { "message": "動画のサムネイルの再生ボタンを非表示にする" },
   "css_hide_url_thumb": { "message": "サムネイル画像に関連するリンクを非表示にする (iOS/Android の公式 Twitter クライアントと同様)" },
   "css_no_col_icns": { "message": "カラムのヘッダーアイコンを非表示にする" },

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -299,7 +299,7 @@
           <li data-setting-name="og_dark_theme">
             <input type="checkbox" name="css.og_dark_theme" id="og_dark_theme">
             <label for="og_dark_theme" data-lang="css_og_dark_theme">Re-enable the Dark theme (pre February 2018)</label>
-            <small>This is experimental and can break at any point!</small>
+            <small data-lang="css_experimental_warning">This is experimental and can break at any point!</small>
           </li>
           <li data-setting-name="no_col_icns">
             <input type="checkbox" name="css.no_col_icns" id="no_col_icns">


### PR DESCRIPTION
When there is no text in `src/_locales/en/messages.json` corresponding to a new text added to the setting file, all the following options fail to be translated into other languages. 

<img width="1177" alt="2018-02-03 16 08 37" src="https://user-images.githubusercontent.com/1425259/35765148-9e43d5a4-0901-11e8-8c23-544906b8d914.png">

