### PR TITLE
Fix getting Pixiv thumbnail on user's page

### DIFF
--- a/src/js/util/providers/pixiv.js
+++ b/src/js/util/providers/pixiv.js
@@ -4,7 +4,7 @@ export default function ($) {
   return {
     name: 'Pixiv',
     setting: 'pixiv_net',
-    re: /pixiv\.net\/(?:member_illust\.php|novel\/|i\/|n\/)/,
+    re: /pixiv\.net\/(?:member_illust\.php\?.*(?:mode=)|novel\/|i\/|n\/)/,
     default: true,
     callback: (url) => {
       return fetch(url.replace('http:', 'https:'))


### PR DESCRIPTION
In #303, it cannot get Pixiv thumbnail in this URL.

* https://www.pixiv.net/member_illust.php?id=3901537