### PR TITLE
Add feature to reduce amount of loaded DMs

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -193,6 +193,7 @@
   "ctrl_changes_interactions__mode__owner": { "message": "column's owner" },
   "ctrl_changes_interactions__mode__dialog": { "message": "follow dialog" },
   "keep_hashtags": { "message": "Keep tweeted hashtags in the compose box." },
+  "conversation_entry_cut": { "message": "Reduce amount of loaded direct messages (10 instead of 100 per opening) to save performance" },
 
   "btd_thx": { "message": "Thanks for installing Better TweetDeck!" },
   "btd_get_started": { "message": "Let's get started!" },

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -72,6 +72,7 @@ const defaultSettings = {
   thumbnails: {},
   custom_css_style: '',
   btd_logo: true,
+  conversation_entry_cut: false,
 };
 
 // We want to know if there are any other versions of BTD out there.

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -39,6 +39,10 @@ if (SETTINGS.no_tco) {
   };
 }
 
+if (SETTINGS.conversation_entry_cut) {
+  TD.services.TwitterConversation.CONVERSATION_ENTRY_COUNT = 10;
+}
+
 const getMediaParts = (chirp, url) => {
   return {
     fileExtension: url

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -282,6 +282,10 @@
               </select>
               </label>
             </li>
+            <li data-setting-name="conversation_entry_cut">
+              <input type="checkbox" name="conversation_entry_cut" id="conversation_entry_cut">
+              <label for="conversation_entry_cut" data-lang="conversation_entry_cut" data-new-feat>Reduce amount of loaded direct messages (10 instead of 100 per opening) to save performance</label>
+            </li>
           </ul>
         </div>
 


### PR DESCRIPTION
Okay, the feature in itself is _really simple_.

It changes the behaviour Conversation columns (basically Direct Messages in TD terms) behave after their initial load.

The initial load of the message endpoint always fills in 20 messages (that also is Twitter's API default). After every subsequent opening of a conversation however, TweetDeck will load 100 additional messages. No additional loading if you reach the bottom, just 100 messages once you open it. Every time. So the amount increases from 20 to 100 to 200 and so on...

Considering there is no _"render cache"_ or partial conversation display, TD always has to re-render the whole list, and with the amount of markup generated and added, if you reach several hundreds of loaded messages (depending on available processing) TweetDeck starts to get incredibly slow and almost unusable with a specific conversation open.

My fix isn't a real _fix_, but this will delay the above mentioned issue significantly. In fact so much, except people are really active in their DMs, a typical user session should not have issues anymore.

**Why is it not configurable?** Because someone will have the smart idea to set this to an incredibly high number, which either slows it down in an instant or just crashes TweetDeck.