### PR TITLE
Fix media overflow when using small windows

### DIFF
--- a/src/css/features/no-bg-modal.css
+++ b/src/css/features/no-bg-modal.css
@@ -37,7 +37,6 @@ html.btd-on {
   }
 
   .btd__no_bg_modal .med-embeditem {
-    min-width: 600px;
     left: 50%;
     transform: translate(-50%, 0);
     overflow: hidden;


### PR DESCRIPTION
Expanding media overflows for small screens/windows e.g.

![before](https://user-images.githubusercontent.com/1565924/45833777-25998080-bccb-11e8-8d24-ec15405bb862.PNG)


Issue seems to be with this:
https://github.com/eramdam/BetterTweetDeck/blob/6c97232780c8539d5ec4f8768a6094420830cf2f/src/css/features/no-bg-modal.css#L40

You can workaround it by adding this to your Custom CSS
html.btd-on .btd__no_bg_modal .med-embeditem{min-width:0px}

e.g.

![after](https://user-images.githubusercontent.com/1565924/45833814-3d710480-bccb-11e8-9683-7aee5be90c0d.PNG)
