### PR TITLE
include `.DS_Store` in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules
 dist/
 artifacts/*


### PR DESCRIPTION
~~can't believe this is actually my first PR here~~

Found out that `.DS_Store` is not gitignored when cloning on my Macbook. This fixes it.