### PR TITLE
Remove "unsafe-*" directives from manifest's CSP

### DIFF
--- a/tools/manifests/common.js
+++ b/tools/manifests/common.js
@@ -70,7 +70,7 @@ const common = {
   content_security_policy: [
     `img-src https: data: 'self' *`,
     `default-src`,
-    `style-src 'self'`,
+    `style-src 'none'`,
     `connect-src * https:`,
     `script-src 'self'`,
   ].join('; '),

--- a/tools/manifests/common.js
+++ b/tools/manifests/common.js
@@ -67,7 +67,7 @@ const common = {
     'js/inject.js',
     'options/options.html',
   ],
-  content_security_policy: `img-src https: data: 'self' *; default-src; connect-src * https:; style-src 'unsafe-inline'; script-src 'self';`,
+  content_security_policy: `img-src https: data: 'self' *; default-src; connect-src * https:; script-src 'self';`,
 };
 
 if (process.env.NODE_ENV === 'dev') {

--- a/tools/manifests/common.js
+++ b/tools/manifests/common.js
@@ -67,7 +67,13 @@ const common = {
     'js/inject.js',
     'options/options.html',
   ],
-  content_security_policy: `img-src https: data: 'self' *; default-src; connect-src * https:; script-src 'self';`,
+  content_security_policy: [
+    `img-src https: data: 'self' *`,
+    `default-src`,
+    `style-src 'self'`,
+    `connect-src * https:`,
+    `script-src 'self'`,
+  ].join('; '),
 };
 
 if (process.env.NODE_ENV === 'dev') {

--- a/tools/manifests/firefox.js
+++ b/tools/manifests/firefox.js
@@ -21,5 +21,4 @@ module.exports = Object.assign(require('./common.js'), {
     'webRequestBlocking',
     ...urls,
   ],
-  content_security_policy: `img-src https: data: 'self' *; media-src * https:; connect-src * https:; object-src 'self'; script-src 'self';`,
 });

--- a/tools/manifests/firefox.js
+++ b/tools/manifests/firefox.js
@@ -21,5 +21,5 @@ module.exports = Object.assign(require('./common.js'), {
     'webRequestBlocking',
     ...urls,
   ],
-  content_security_policy: `img-src https: data: 'self' *; media-src * https:; connect-src * https:; style-src 'unsafe-inline'; object-src 'self'; script-src 'self';`,
+  content_security_policy: `img-src https: data: 'self' *; media-src * https:; connect-src * https:; object-src 'self'; script-src 'self';`,
 });


### PR DESCRIPTION
Fixes https://github.com/eramdam/BetterTweetDeck/issues/426