### PR TITLE
Remove domify to avoid favicon changing bug

### DIFF
--- a/docs/extend/providers.md
+++ b/docs/extend/providers.md
@@ -47,8 +47,8 @@ These previews are mostly embeds or images, depending on service type.
 
         // data is the fetchPage response
         const el = secureDomify.parse(data.target.response);
-        const thumbnail = secureDomify.getAttributeFromNode('[property="twitter:image"]', el, 'content');
-        const embedURL = secureDomify.getAttributeFromNode('[property="twitter:player"]', el, 'content');
+        const thumbnail = secureDomify.getAttributeFromNode('[data-property="twitter:image"]', el, 'content');
+        const embedURL = secureDomify.getAttributeFromNode('[data-property="twitter:player"]', el, 'content');
       ```
 * Import your provider into [src/js/util/providers/index.js](https://github.com/eramdam/BetterTweetDeck/blob/master/src/js/util/providers/index.js):
   ```js

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,6 +284,11 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@types/dompurify": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-0.0.33.tgz",
+      "integrity": "sha512-lUN9iC6b4txeaEef2PW7zIdhEKAp0Sw9bymOcXXZ7BaepB0nsDJYcLIrFfgpIkRSoZWBJ8IcYunB2hAXuHL1NA=="
+    },
     "@types/node": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.0.tgz",
@@ -4018,15 +4023,10 @@
         "domelementtype": "1"
       }
     },
-    "domify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.0.tgz",
-      "integrity": "sha1-EUg2F/dk+GlZdbS9x5sU8IA7Yps="
-    },
     "dompurify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-1.0.4.tgz",
-      "integrity": "sha512-Y/HFiY5NACdpMs8DJQhNCjF8Kj6msjQRLW5fgD628gBk6a2tjZcVN57SF/PvEgogxsrBPXOF0f3d6qNiAdIYoA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.0.0.tgz",
+      "integrity": "sha512-i8LWSIMDpGmv7AbOcQOyy54L4TrRhjs6yrSessoNeYspsAtgaKiiGeBAG5959qLfhGvyndkHeyZWxx0dd4iDxw=="
     },
     "domutils": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/eramdam/BetterTweetDeck",
   "dependencies": {
+    "@types/dompurify": "0.0.33",
     "apollo-fetch": "^0.7.0",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.4",
@@ -46,8 +47,7 @@
     "css-loader": "^0.28.11",
     "cssnano": "3.10.0",
     "del": "^3.0.0",
-    "domify": "^1.4.0",
-    "dompurify": "^1.0.2",
+    "dompurify": "^2.0.0",
     "emoji-js": "3.4.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "fecha": "^2.3.3",

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -762,7 +762,7 @@ onEvent('BTDC_gotMediaGalleryChirpHTML', (ev, data) => {
     '<div class="js-med-tweet med-tweet"></div>',
     `<div class="js-med-tweet med-tweet">${markup}</div>`,
   );
-  const tweetNode = secureDomify.parse(tweetMarkupString);
+  const tweetNode = secureDomify.parse(tweetMarkupString, false);
 
   closeOpenModal();
 

--- a/src/js/util/providers/bandcamp.js
+++ b/src/js/util/providers/bandcamp.js
@@ -15,31 +15,31 @@ export default function ($) {
 
         const el = secureDomify.parse(data.target.response);
         let thumbnail = secureDomify.getAttributeFromNode(
-          '[property="og:image"]',
+          '[data-property="og:image"]',
           el,
           'content',
         );
 
         if (!thumbnail) {
           thumbnail = secureDomify.getAttributeFromNode(
-            '[property="twitter:image"]',
+            '[data-property="twitter:image"]',
             el,
             'content',
           );
         }
 
         const embedURL = secureDomify.getAttributeFromNode(
-          '[property="twitter:player"]',
+          '[data-property="twitter:player"]',
           el,
           'content',
         );
         const height = secureDomify.getAttributeFromNode(
-          '[property="twitter:player:height"]',
+          '[data-property="twitter:player:height"]',
           el,
           'content',
         );
         const width = secureDomify.getAttributeFromNode(
-          '[property="twitter:player:width"]',
+          '[data-property="twitter:player:width"]',
           el,
           'content',
         );

--- a/src/js/util/providers/pixiv.js
+++ b/src/js/util/providers/pixiv.js
@@ -13,7 +13,7 @@ export default function ($) {
           // Only domify <head> part to prevent from making requests for i.pximg.net
           const doc = secureDomify.parse(/<head>[^]+<\/head>/m.exec(html)[0]);
           const imgUrl = secureDomify.getAttributeFromNode(
-            'meta[property="twitter:image"], meta[property="og:image"]',
+            'meta[data-property="twitter:image"], meta[data-property="og:image"]',
             doc,
             'content',
           );

--- a/src/js/util/secureDomify.js
+++ b/src/js/util/secureDomify.js
@@ -1,4 +1,3 @@
-import domify from 'domify';
 import dompurify from 'dompurify';
 
 export const purifyConfig = {
@@ -19,11 +18,22 @@ export function getAttributeFromNode(selector, node, attribute) {
     return '';
   }
 
-  return dompurify.sanitize(attr);
+  return dompurify.sanitize(attr, {
+    FORBID_TAGS: ['link', 'style'],
+  });
 }
 
-export function parse(html) {
-  const doc = domify(html);
+export function parse(html, wholeDocument = true) {
+  const result = dompurify.sanitize(
+    html.replace(/property=/g, 'data-property='),
+    {
+      ADD_TAGS: ['meta', 'head', 'iframe'],
+      FORBID_TAGS: ['body'],
+      ADD_ATTR: [...purifyConfig.ADD_ATTR, 'content'],
+      RETURN_DOM: true,
+      WHOLE_DOCUMENT: wholeDocument,
+    },
+  );
 
-  return doc;
+  return result;
 }

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -1,13 +1,12 @@
 /* eslint global-require: 0 */
-import path from 'path';
-import fs from 'fs';
-
+import CleanWebpackPlugin from 'clean-webpack-plugin';
+import config from 'config';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
-import CleanWebpackPlugin from 'clean-webpack-plugin';
+import fs from 'fs';
 import GenerateJsonPlugin from 'generate-json-webpack-plugin';
+import path from 'path';
 import ZipPlugin from 'zip-webpack-plugin';
-import config from 'config';
 
 const extractContent = new ExtractTextPlugin('css/index.css');
 const extractOptions = new ExtractTextPlugin('options/css/index.css');
@@ -40,7 +39,7 @@ const staticFiles = [
 ];
 
 const DIST_FOLDER = 'dist';
-const IS_PRODUCTION = process.env.NODE_ENV !== 'dev';
+const IS_PRODUCTION = process.env.NODE_ENV !== 'development';
 const POSSIBLE_BROWSERS = ['chrome', 'firefox'];
 
 const cssLoaders = {


### PR DESCRIPTION
I've been told that the favicon of TweetDeck changes whenever BTD parses the content of a Bandcamp page. While it seems to be inoffensive as no JS can be ran this way, it might cause other weird issues so I'm removing `domify` entirely and using DOMPurify everywhere I can to ensure no XSS is possible.