### PR TITLE
Add timestamp templates to the download filename

### DIFF
--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -187,7 +187,7 @@
   "download_filename_format": { "message": "Formát názvu stažených souborů" },
   "download_filename_format_parameters": {
     "message":
-      "Můžete použít následující proměnné: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}}</code>"
+      "Můžete použít následující proměnné: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code>"
   },
   "ctrl_changes_interactions__enabled": {
     "message":

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -208,7 +208,7 @@
   },
   "download_filename_format_parameters": {
     "message":
-      "Du kannst die folgenden Variablen verwenden: <code>{{postedUser}} {{fileName}} {{fileExtension}}</code>"
+      "Du kannst die folgenden Variablen verwenden: <code>{{postedUser}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code>"
   },
   "ctrl_changes_interactions__enabled": {
     "message":

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -202,7 +202,7 @@
   "download_filename_format": { "message": "Download file name format" },
   "download_filename_format_parameters": {
     "message":
-      "You can use the following variables: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}}</code>"
+      "You can use the following variables: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code>"
   },
   "ctrl_changes_interactions__enabled": {
     "message":

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -213,7 +213,7 @@
   },
   "download_filename_format_parameters": {
     "message":
-      "Vous pouvez utiliser les variables suivantes: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}}</code>"
+      "Vous pouvez utiliser les variables suivantes: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code>"
   },
   "ctrl_changes_interactions": {
     "message":

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -202,7 +202,7 @@
   "download_filename_format": { "message": "ダウンロードするファイル名のフォーマット" },
   "download_filename_format_parameters": {
     "message":
-      "次の変数が利用できます: <code>{{postedUser}}/{{tweetId}}/{{fileName}}/{{fileExtension}}</code> (それぞれ、ツイートユーザー名/ツイートID/ファイル名/ファイルの拡張子に置換されます)"
+      "次の変数が利用できます: <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code> (それぞれ「ツイートユーザー名」「ツイートID」「ファイル名」「ファイルの拡張子」ツイートした日時の「年」「月」「日」「時」「分」「秒」に置換されます)"
   },
   "ctrl_changes_interactions__enabled": {
     "message":

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -65,7 +65,7 @@ const defaultSettings = {
   block_item: false,
   download_item: false,
   download_filename_format:
-    '{{postedUser}}-{{tweetId}}-{{fileName}}.{{fileExtension}}',
+    '{{postedUser}}-{{year}}{{month}}{{day}}-{{hours}}{{minutes}}{{seconds}}-{{tweetId}}-{{fileName}}.{{fileExtension}}',
   ctrl_changes_interactions: {
     enabled: false,
     mode: 'owner',

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -55,6 +55,12 @@ const getMediaParts = (chirp, url) => {
       ? chirp.retweetedStatus.user.screenName
       : chirp.user.screenName,
     tweetId: chirp.retweetedStatus ? chirp.retweetedStatus.id : chirp.id,
+    year: chirp.created.getFullYear(),
+    month: (chirp.created.getMonth() + 1).toString().padStart(2, '0'),
+    day: chirp.created.getDate().toString().padStart(2, '0'),
+    hours: chirp.created.getHours().toString().padStart(2, '0'),
+    minutes: chirp.created.getMinutes().toString().padStart(2, '0'),
+    seconds: chirp.created.getSeconds().toString().padStart(2, '0'),
   };
 };
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -273,7 +273,7 @@
               <label for="download_filename_format" data-lang="download_filename_format" data-new-feat>Download file name format</label>
               <br />
               <small data-lang="download_filename_format_parameters">You can use the following variables:
-                <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}}</code>
+                <code>{{postedUser}} {{tweetId}} {{fileName}} {{fileExtension}} {{year}} {{month}} {{day}} {{hours}} {{minutes}} {{seconds}}</code>
               </small>
             </li>
             <li data-setting-name="keep_hashtags">


### PR DESCRIPTION
## What

This PR adds timestamp templates to the download filename and enables to embed the date and time of the tweet into the filename strings.

The introduced templates are following: 
`year`, `month`, `day`, `hours`, `minutes`, and `secods`.

Also, the default template is changed to include the date and time.

## Why

This fixes #414.

The date and time can be determined from the tweet ID unless the tweet is deleted. However, as the comment on #414 says, it's better to include tweet date for the archiving purpose.