### PR TITLE
Fix some templates not being replaced

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -21,6 +21,24 @@ try {
 }
 
 window.$ = mR && mR.findFunction('jQuery') && mR.findFunction('jquery:')[0];
+window.mR = mR;
+
+const OGGetHogan = mR.findModule('getHogan')[0].getHogan;
+
+// Thanks to @pixeldesu for the sick moduleRaid trick
+// As of October 12th 2019 TweetDeck started putting mustache templates into webpack modules
+// meaning modifying them in place in TD.mustaches isn't working anymore, this proxies the calls to the template rendering into TD.mustaches for compatibility.
+// This might break the day TD.mustaches completely disappears but...let's hope it's not too soon.
+mR.findModule('getHogan')[0].getHogan = function getHogan(...args) {
+  const [template] = args;
+  const fqtn = `${template}.mustache`;
+
+  if (TD.mustaches[fqtn]) {
+    return TD.mustaches[fqtn];
+  }
+
+  return OGGetHogan(...args);
+};
 
 if (SETTINGS.no_tco) {
   const dummyEl = document.createElement('span');

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -21,7 +21,6 @@ try {
 }
 
 window.$ = mR && mR.findFunction('jQuery') && mR.findFunction('jquery:')[0];
-window.mR = mR;
 
 const OGGetHogan = mR.findModule('getHogan')[0].getHogan;
 


### PR DESCRIPTION
This implements @pixeldesu's trick to proxy the `getHogan` internal method in order to optionally grab our own modified mustache templates instead of the in-bundle one when possible.

Right now it seems safe but it might not be if the content of `TD.mustaches` and whatever is inside the modules start to drift apart but migration will be a hassle so I'll assume this stays safe for a while 🤞 