### PR TITLE
Better, simpler and working CSS to remove the background in the modal

### DIFF
--- a/src/css/features/no-bg-modal.css
+++ b/src/css/features/no-bg-modal.css
@@ -1,52 +1,22 @@
-html.btd-on {
-  .btd__no_bg_modal {
-    .med-fullpanel {
-      box-shadow: none;
-      background: transparent;
-    }
+.btd__no_bg_modal {
+  .overlay,
+  .ovl {
+    background: rgba(0, 0, 0, 0.8) !important;
   }
 
-  .btd__no_bg_modal :matches(.mdl-media-prev, .mdl-media-next) {
+  .js-modal-panel.mdl.s-full.med-fullpanel {
     background: transparent;
-    z-index: 10;
-
-    .icon {
-      background: color(#151515 a(60%));
-      border-radius: 50%;
-      width: 42px;
-      height: 42px;
-      margin-left: -21px;
-      margin-top: -21px;
-    }
-
-    .icon::before {
-      position: absolute;
-      left: 45%;
-      top: 50%;
-      transform: translate(-50%, -50%);
-    }
+    pointer-events: none;
+    box-shadow: none;
   }
 
-  .btd__no_bg_modal
-  :matches(.mdl-btn-media, .is-inverted-light .mdl-btn-media) {
-    opacity: 1;
+  .js-mediatable .js-modal-panel .med-embeditem {
+    top: 0;
+    bottom: 0;
   }
 
-  .btd__no_bg_modal .media-img {
-    max-width: 100% !important;
-  }
-
-  .btd__no_bg_modal .med-embeditem {
-    left: 50%;
-    transform: translate(-50%, 0);
-    overflow: hidden;
-  }
-
-  .btd__no_bg_modal .med-tray {
-    z-index: 9;
-  }
-
-  .btd__no_bg_modal :matches(.ovl, .overlay) {
-    background: color(black a(80%));
+  .js-mediatable .js-modal-panel .js-mediaembed,
+  .mdl-btn-media {
+    pointer-events: all;
   }
 }


### PR DESCRIPTION
This fixes the "no background behind modal" option after TweetDeck's recent update that uses a regular html5 video player for videos.

And it's cleaner/simpler anyway.