### PR TITLE
Remove the need for the `tabs` permission

### DIFF
--- a/src/css/features/no-bg-modal.css
+++ b/src/css/features/no-bg-modal.css
@@ -57,7 +57,8 @@ html.btd-on {
 
   .js-mediatable .js-modal-panel .js-mediaembed,
   .mdl-btn-media,
-  .btd-embed-container > * {
+  .btd-embed-container > *,
+  .med-tweet {
     pointer-events: all;
   }
 }

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -185,21 +185,7 @@ BHelper.settings.getAll((settings) => {
 
     // We create the context menu item
     if (newSettings.share_item && newSettings.share_item.enabled) {
-      if (chrome.permissions) {
-        chrome.permissions.contains(
-          {
-            permissions: ['tabs'],
-          },
-          (hasTabs) => {
-            if (!hasTabs) {
-              return;
-            }
-            createMenuItem(newSettings);
-          }
-        );
-      } else {
-        createMenuItem(newSettings);
-      }
+      createMenuItem(newSettings);
     }
   });
 });

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -307,19 +307,6 @@
         <h2 class="section-title" data-lang="shared_btd_h1">Sharing</h2>
 
         <div class="settings-section" data-require-permission>
-          <p data-lang="share_btd_p1" data-hidden-firefox>In order to use the "Share on TweetDeck" feature, you'll need to approve certain permissions which you can do so
-            by clicking below</p>
-
-          <p data-hidden-firefox>
-            <button class="plain-button" data-lang="share_request" data-ask-permissions>Request tabs reading permissions</button>
-          </p>
-
-          <p data-lang="share_btd_p2">Better TweetDeck can
-            <strong>NOT</strong> read or track the contents of any open tabs.</p>
-
-          <p data-lang="share_btd_p3">Feel free to read
-            <a href="https://developer.chrome.com/extensions/tabs">Chrome's documentation</a> about this permission for more details.</p>
-
           <p>
             <strong data-lang="share_btd_p4">Any modification on this page will be applied after a browser restart</strong>
           </p>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -407,38 +407,6 @@ BHelper.settings.get(
   true
 );
 
-if (chrome.permissions) {
-  chrome.permissions.contains(
-    {
-      permissions: ['tabs'],
-    },
-    (hasTabs) => {
-      if (!hasTabs) {
-        $('[data-require-permission] input').each((i, el) => $(el).prop('disabled', true));
-      } else {
-        $('[data-ask-permissions]').prop('disabled', true);
-        $('[data-ask-permissions]').text(BHelper.getMessage('share_granted'));
-      }
-    }
-  );
-
-  $('[data-ask-permissions]').on('click', (ev) => {
-    ev.preventDefault();
-    chrome.permissions.request(
-      {
-        permissions: ['tabs'],
-      },
-      (granted) => {
-        if (granted) {
-          $('[data-require-permission] input').each((i, el) => $(el).prop('disabled', false));
-          $(ev.target).prop('disabled', true);
-          $(ev.target).text(BHelper.getMessage('share_granted'));
-        }
-      }
-    );
-  });
-}
-
 // Auto-select sidebar items
 $('.sidebar-nav:first-child a:first-child, .content-block:first-child').addClass('-selected');
 

--- a/tools/manifests/common.js
+++ b/tools/manifests/common.js
@@ -47,7 +47,6 @@ const common = {
   },
   icons: isBeta ? betaIcons : icons,
   permissions: ['storage', 'contextMenus', 'webRequest', 'webRequestBlocking', ...urls],
-  optional_permissions: ['tabs'],
   options_ui: {
     page: 'options/ui/ui.html',
     chrome_style: false,

--- a/tools/manifests/firefox.js
+++ b/tools/manifests/firefox.js
@@ -12,6 +12,6 @@ module.exports = Object.assign(require('./common.js'), {
       strict_min_version: '48.0',
     },
   },
-  permissions: ['storage', 'contextMenus', 'tabs', 'webRequest', 'webRequestBlocking', ...urls],
+  permissions: ['storage', 'contextMenus', 'webRequest', 'webRequestBlocking', ...urls],
   content_security_policy: `img-src https: data: 'self' *; media-src * https:; connect-src * https:; style-src 'unsafe-inline'; object-src 'self'; script-src 'self';`,
 });


### PR DESCRIPTION
No more `tabs` permission ❌🚫 Better TweetDeck has progressed past the need for the `tabs` permission ❌🚫