### PR TITLE
Add content warnings

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -172,6 +172,12 @@
     "message":
       "Wenn du eine Spalte ausklappst, wird der Feed fortgesetzt und scrollt automatisch zurück nach oben, anstatt dort stehenzubleiben, wo du sie das letzte Mal gesehen hast"
   },
+  "content_warnings": {
+    "message": "Zeige Inhaltswarnungen für gekennzeichnete Tweets"
+  },
+  "content_warnings_hint": {
+    "message": "Wir prüfen Tweets nach häufig genutzten 'cw/tw/cn'-Warnungen um diese anzuzeigen"
+  },
 
   "regex_filter": {
     "message":

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -171,6 +171,12 @@
     "message":
       "When you uncollapse a column, it will unpause the feed it so that it automatically scrolls back to the top instead of staying where you left it"
   },
+  "content_warnings": {
+    "message": "Show content warnings for appropriately marked tweets"
+  },
+  "content_warnings_hint": {
+    "message": "We'll check tweets for containing commonly used cw/tw/cn warnings to display these!"
+  },
   "btd_logo": {
     "message": "Change TweetDeck's logo in the left bottom corner for Better TweetDeck's logo"
   },

--- a/src/css/features/content-warnings.css
+++ b/src/css/features/content-warnings.css
@@ -1,0 +1,34 @@
+.btd-content-warning:not([open]) ~ .media-preview,
+.btd-content-warning:not([open]) ~ .quoted-tweet,
+.btd-content-warning:not([open]) ~ .js-card-container {
+  display: none;
+}
+
+.btd-content-warning summary {
+  list-style-type: none;
+}
+
+.btd-content-warning summary::-webkit-details-marker {
+  display: none;
+}
+
+.btd-content-warning summary:after {
+  content: 'Show More';
+  display: inline-block;
+  background-color: #1da1f2;
+  color: #fff;
+  font-size: 0.7em;
+  font-weight: bold;
+  padding: 3px 7px;
+  border-radius: 36px;
+  margin-left: 5px;
+}
+
+.btd-content-warning summary:hover:after,
+.btd-content-warning[open] summary:after {
+  background-color: #005fd1;
+}
+
+.btd-content-warning[open] summary:after {
+  content: 'Show Less';
+}

--- a/src/css/features/content-warnings.css
+++ b/src/css/features/content-warnings.css
@@ -19,7 +19,7 @@
   color: #fff;
   font-size: 0.7em;
   font-weight: bold;
-  padding: 3px 7px;
+  padding: 0 6px;
   border-radius: 36px;
   margin-left: 5px;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -10,6 +10,7 @@
 @import "./features/bigger-emojis.css";
 @import "./features/character-count.css";
 @import "./features/collapse-dms.css";
+@import "./features/content-warnings.css";
 @import "./features/flash-tweets.css";
 @import "./features/gray-notif-icns.css";
 @import "./features/hide-context.css";

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -28,6 +28,7 @@ const defaultSettings = {
   clear_column_action: false,
   collapse_columns: false,
   collapse_columns_pause: true,
+  content_warnings: false,
   uncollapse_columns_unpause: false,
   css: {
     round_pic: true,

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -6,6 +6,7 @@ import PromiseEach from 'promise-each';
 import qs from 'query-string';
 
 import * as BHelper from './util/browserHelper';
+import contentWarningHandler from './util/cw';
 import {
   insertEmojiCompletionDropdownHolder,
   setupEmojiCompletionEventHandlers,
@@ -435,6 +436,10 @@ function tweetHandler(tweet, columnKey, parent) {
   }
 
   nodes.forEach((node) => {
+    if (SETTINGS.content_warnings) {
+      contentWarningHandler(node, tweet);
+    }
+
     if (tweet.retweetedStatus) {
       node.classList.add('btd-is-retweet');
     }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -6,7 +6,6 @@ import PromiseEach from 'promise-each';
 import qs from 'query-string';
 
 import * as BHelper from './util/browserHelper';
-import contentWarningHandler from './util/cw';
 import {
   insertEmojiCompletionDropdownHolder,
   setupEmojiCompletionEventHandlers,
@@ -436,10 +435,6 @@ function tweetHandler(tweet, columnKey, parent) {
   }
 
   nodes.forEach((node) => {
-    if (SETTINGS.content_warnings) {
-      contentWarningHandler(node, tweet);
-    }
-
     if (tweet.retweetedStatus) {
       node.classList.add('btd-is-retweet');
     }

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -6,6 +6,7 @@ import { debounce, unescape } from 'lodash';
 import moduleRaid from 'moduleraid';
 
 import AdvancedMuteEngine from './util/ame';
+import contentWarningHandler from './util/cw';
 import * as GIFS from './util/gifs';
 import { keepHashtags } from './util/keepHashtags';
 import Log from './util/logger';
@@ -768,6 +769,10 @@ const handleInsertedNode = (element) => {
 
   if (!chirp) {
     return;
+  }
+
+  if (SETTINGS.content_warnings) {
+    contentWarningHandler(element, decorateChirp(chirp));
   }
 
   proxyEvent('gotChirpForColumn', { chirp: decorateChirp(chirp), colKey });

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -5,7 +5,7 @@ export default function contentWarningHandler(node, tweet) {
   }
 
   const cwRegex = /^[[(]?(?:cw|tw|cn)(?:\W+)?\s([^\n|\]|)|…]+)[\])…]?(?:\n+)?((?:.+)?\n?)+$/gi;
-  const matches = [...tweet.htmlText.matchAll(cwRegex)];
+  const matches = [...tweet.text.matchAll(cwRegex)];
 
   if (matches.length > 0) {
     const warning = matches[0][1];
@@ -15,7 +15,7 @@ export default function contentWarningHandler(node, tweet) {
     details.classList.add('btd-content-warning', 'is-actionable');
 
     const summary = document.createElement('summary');
-    summary.innerHTML = warning;
+    summary.innerHTML = TD.util.transform(warning);
 
     // Stopping event propagation because everything inside tweets opens the detail view
     summary.addEventListener('click', (e) => {
@@ -27,7 +27,7 @@ export default function contentWarningHandler(node, tweet) {
     if (text) {
       const tweetText = document.createElement('p');
       tweetText.classList.add('tweet-text', 'js-tweet-text', 'with-linebreaks');
-      tweetText.innerHTML = text.trim();
+      tweetText.innerHTML = TD.util.transform(text.trim());
       details.appendChild(tweetText);
     }
 

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -4,7 +4,7 @@ export default function contentWarningHandler(node, tweet) {
     return false;
   }
 
-  const cwRegex = /^[[]?(?:cw|tw|cn)(?:\W+)?\s([^\n|\]]+)[\]]?(?:\n+)?(.+)?$/gi;
+  const cwRegex = /^[[(]?(?:cw|tw|cn)(?:\W+)?\s?([^\n|\]|)|…]+)[\])…]?(?:\n+)?((?:.+)?\n?)+$/gi;
   const matches = [...tweet.htmlText.matchAll(cwRegex)];
 
   if (matches.length > 0) {

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -1,0 +1,35 @@
+export default function contentWarningHandler(node, tweet) {
+  // Skip if we already have a content warning or are in a detail view
+  if (node.querySelectorAll('.btd-content-warning, .tweet-detail').length > 0) {
+    return false;
+  }
+
+  const cwRegex = /^[[]?(?:cw|tw|cn)\W+?\s([^\n|\]]+)[\]]?(?:\n+)?(.+)?$/gi;
+  const matches = [...tweet.htmlText.matchAll(cwRegex)];
+
+  if (matches.length > 0) {
+    const warning = matches[0][1];
+    const text = matches[0][2];
+
+    const details = document.createElement('details');
+    details.classList.add('btd-content-warning', 'is-actionable');
+
+    const summary = document.createElement('summary');
+    summary.innerHTML = warning;
+    details.appendChild(summary);
+
+    if (text) {
+      const tweetText = document.createElement('p');
+      tweetText.classList.add('tweet-text', 'js-tweet-text', 'with-linebreaks');
+      tweetText.innerHTML = text.trim();
+      details.appendChild(tweetText);
+    }
+
+    // Stopping event propagation because everything inside tweets opens the detail view
+    details.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+
+    node.querySelector('.tweet-text').replaceWith(details);
+  }
+}

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -4,7 +4,7 @@ export default function contentWarningHandler(node, tweet) {
     return false;
   }
 
-  const cwRegex = /^[[]?(?:cw|tw|cn)\W+?\s([^\n|\]]+)[\]]?(?:\n+)?(.+)?$/gi;
+  const cwRegex = /^[[]?(?:cw|tw|cn)(?:\W+)?\s([^\n|\]]+)[\]]?(?:\n+)?(.+)?$/gi;
   const matches = [...tweet.htmlText.matchAll(cwRegex)];
 
   if (matches.length > 0) {

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -16,6 +16,12 @@ export default function contentWarningHandler(node, tweet) {
 
     const summary = document.createElement('summary');
     summary.innerHTML = warning;
+
+    // Stopping event propagation because everything inside tweets opens the detail view
+    summary.addEventListener('click', (e) => {
+      e.stopPropagation();
+    });
+
     details.appendChild(summary);
 
     if (text) {
@@ -24,11 +30,6 @@ export default function contentWarningHandler(node, tweet) {
       tweetText.innerHTML = text.trim();
       details.appendChild(tweetText);
     }
-
-    // Stopping event propagation because everything inside tweets opens the detail view
-    details.addEventListener('click', (e) => {
-      e.stopPropagation();
-    });
 
     node.querySelector('.tweet-text').replaceWith(details);
   }

--- a/src/js/util/cw.js
+++ b/src/js/util/cw.js
@@ -4,7 +4,7 @@ export default function contentWarningHandler(node, tweet) {
     return false;
   }
 
-  const cwRegex = /^[[(]?(?:cw|tw|cn)(?:\W+)?\s?([^\n|\]|)|…]+)[\])…]?(?:\n+)?((?:.+)?\n?)+$/gi;
+  const cwRegex = /^[[(]?(?:cw|tw|cn)(?:\W+)?\s([^\n|\]|)|…]+)[\])…]?(?:\n+)?((?:.+)?\n?)+$/gi;
   const matches = [...tweet.htmlText.matchAll(cwRegex)];
 
   if (matches.length > 0) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -384,6 +384,11 @@
               <input type="checkbox" name="make_search_columns_first" id="make_search_columns_first">
               <label for="make_search_columns_first" data-lang="make_search_columns_first" data-new-feat>Add search columns in front of first column</label>
             </li>
+            <li data-setting-name="content_warnings">
+              <input type="checkbox" name="content_warnings" id="content_warnings">
+              <label for="content_warnings" data-lang="content_warnings" data-new-feat>Show content warnings for appropriately marked tweets</label>
+              <small data-lang="content_warnings_hint">We'll check tweets for containing commonly used cw/tw/cn warnings to display these!</small>
+            </li>
             <li>
               <input type="checkbox" name="custom_columns_width.enabled" id="column_width" data-ghost>
               <label for="column_width" data-lang="custom_width_columns">Custom width for columns:</label>


### PR DESCRIPTION
I know BTD 3.x is actually in a feature-freeze state, maybe we can still sneak this one in!

**Content warnings!** Known from fediverse software, something really useful for content someone might not want to see.

I'm not alterting compose behaviour here, I'm just checking tweets for common cw-patterns used on Twitter.

Some examples:
```
[cw: some warning]
cw: some warning
cw//// some warning
...
```

The main 3 text parts I check for content warnings are `cn`/`tw`/`cw` because these are the most common ones I know of, if there are any more you know, I can extend the regex to include them.

As long as the CW is not opened, media/quotes/polls contained in the same tweet are also not going to be shown.

Also noted: I decided to not apply CWs in tweet detail views because the `tweetHandler` is firing when it gets visible, so you get jumping behaviour.

I added:
* CW utility script to handle the addition of them
* A settings value in `Interface` (default: false)
* Localizations for the settings in english and german

Finally, a screenshot:
![](https://desu.pictures/BroadRedAlbatross7.png)