### PR TITLE
Make sure to have the right filename when saving images/videos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BetterTweetDeck",
-  "version": "3.9.15",
+  "version": "3.9.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7072,9 +7072,9 @@
       }
     },
     "file-saver": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
-      "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
+      "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
     },
     "file-uri-to-path": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "emoji-js": "3.4.0",
     "extract-text-webpack-plugin": "^4.0.0-beta.0",
     "fecha": "^2.3.3",
-    "file-saver": "^1.3.8",
+    "file-saver": "^2.0.2",
     "generate-json-webpack-plugin": "^0.3.1",
     "jquery": "^3.4.1",
     "lodash": "^4.17.14",

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -1,7 +1,7 @@
 import '../css/index.css';
 
 import config from 'config';
-import FileSaver from 'file-saver';
+import { saveAs } from 'file-saver';
 import PromiseEach from 'promise-each';
 import qs from 'query-string';
 
@@ -931,7 +931,7 @@ window.addEventListener('message', (ev) => {
   if (data) {
     switch (data.message) {
       case 'complete_gif':
-        FileSaver.saveAs(dataURItoBlob(data.img), data.name);
+        saveAs(dataURItoBlob(data.img), data.name);
         markGifDlComplete($('[data-btd-dl-gif]') && $('[data-btd-dl-gif]')[0], data.name);
         break;
       case 'resize_imgur':

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-self-assign */
 import Clipboard from 'clipboard';
 import config from 'config';
-import FileSaver from 'file-saver';
+import { saveAs } from 'file-saver';
 import { debounce, unescape, uniqueId } from 'lodash';
 import moduleRaid from 'moduleraid';
 
@@ -1296,12 +1296,15 @@ $('body').on('click', '[data-btd-action="download-media"]', (ev) => {
   const media = getMediaFromChirp(chirp);
 
   media.forEach((item) => {
-    requestMediaItem(item).then((blob) => {
-      FileSaver.saveAs(
-        blob,
-        TD.ui.template.render('btd/download_filename_format', getMediaParts(chirp, item))
-      );
-    });
+    requestMediaItem(item)
+      .then((blob) => blob.arrayBuffer())
+      .then((arrayBuffer) => {
+        const file = new File(
+          [arrayBuffer],
+          TD.ui.template.render('btd/download_filename_format', getMediaParts(chirp, item))
+        );
+        saveAs(file);
+      });
   });
 });
 


### PR DESCRIPTION
Fix #505

For some reason `file-saver` doesn't pass the right filename on Firefox 81, this fix creates a new File object with our custom name instead of relying on whatever `file-saver` is supposed to do to rename the downloaded file.