### PR TITLE
Fix clipboard pasting

### DIFF
--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -1112,19 +1112,20 @@ document.addEventListener('paste', (ev) => {
     const canPopout =
       $('.js-inline-compose-pop, .js-reply-popout').length > 0 &&
       !$('.js-app-content').hasClass('is-open');
-    
-    const findTextbox = $(ev.target).closest(".js-column").find(".js-inline-compose-pop, .js-reply-popout");
+
+    const findTextbox = $(ev.target)
+      .closest('.js-column')
+      .find('.js-inline-compose-pop, .js-reply-popout');
 
     if (canPopout) {
-      if(findTextbox.length > 0) {
-          $(findTextbox)
-            .trigger("click");
-      } else{
-          $('.js-inline-compose-pop, .js-reply-popout')
-            .first()
-            .trigger('click');
+      if (findTextbox.length > 0) {
+        $(findTextbox).trigger('click');
+      } else {
+        $('.js-inline-compose-pop, .js-reply-popout')
+          .first()
+          .trigger('click');
       }
-      
+
       setTimeout(() => {
         $(document).trigger('uiFilesAdded', {
           files,

--- a/src/js/inject.js
+++ b/src/js/inject.js
@@ -1112,11 +1112,19 @@ document.addEventListener('paste', (ev) => {
     const canPopout =
       $('.js-inline-compose-pop, .js-reply-popout').length > 0 &&
       !$('.js-app-content').hasClass('is-open');
+    
+    const findTextbox = $(ev.target).closest(".js-column").find(".js-inline-compose-pop, .js-reply-popout");
 
     if (canPopout) {
-      $('.js-inline-compose-pop, .js-reply-popout')
-        .first()
-        .trigger('click');
+      if(findTextbox.length > 0) {
+          $(findTextbox)
+            .trigger("click");
+      } else{
+          $('.js-inline-compose-pop, .js-reply-popout')
+            .first()
+            .trigger('click');
+      }
+      
       setTimeout(() => {
         $(document).trigger('uiFilesAdded', {
           files,


### PR DESCRIPTION
When there are multiple compose boxes opened, pasting an image from the clipboard does not always popout and add the image to the right tweet. First reported here https://github.com/MehediH/Tweeten/issues/207.

This can cause real problems for users: for example, if someone has a DM open and a tweet reply box open, pasting an image from the clipboard into the DM reply box actually adds it to the tweet. 

This PR fixes it by getting the correct compose box instead of just adding it to the first one :) 