### PR TITLE
Stop using apollo-fetch to render Changelog page

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -2,7 +2,6 @@ module.exports = {
   FirefoxId: 'mycoolextension@mycoolextension.com',
   opera_key: '',
   Client: {
-    github_token: '',
     debug: false,
     remote_inst: true,
     APIs: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1446,14 +1446,6 @@
         }
       }
     },
-    "apollo-fetch": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/apollo-fetch/-/apollo-fetch-0.7.0.tgz",
-      "integrity": "sha512-0oHsDW3Zxx+Of1wuqcOXruNj4Kv55WN69tkIjwkCQDEIrgCpgA2scjChFsgflSVMy/1mkTKCY1Mc0TYJhNRzmw==",
-      "requires": {
-        "cross-fetch": "^1.0.0"
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -4312,15 +4304,6 @@
         "cross-spawn": "^6.0.5"
       }
     },
-    "cross-fetch": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-1.1.1.tgz",
-      "integrity": "sha512-+VJE04+UfxxmBfcnmAu/lKor53RUCx/1ilOti4p+JgrnLQ4AZZIRoe2OEd76VaHyWQmQxqKnV+TaqjHC4r0HWw==",
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.3"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5249,14 +5232,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "requires": {
-        "iconv-lite": "~0.4.13"
-      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -9707,15 +9682,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-forge": {
       "version": "0.7.6",
@@ -17391,11 +17357,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "whatwg-fetch": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-      "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
     "whatwg-url": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@types/dompurify": "^2.0.4",
     "@types/lodash": "^4.14.152",
-    "apollo-fetch": "^0.7.0",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.4",
     "babel-plugin-lodash": "^3.2.11",


### PR DESCRIPTION
I pushed a compiled version of the JS files by mistake and it had a GitHub token, and then I realized I could just, not use that token at all and still use the Github REST API instead of the GraphQL one 😅 