### PR TITLE
Add regular expression filter for usernames

### DIFF
--- a/src/js/util/ame.js
+++ b/src/js/util/ame.js
@@ -86,13 +86,30 @@ export default function() {
       display: {
         global: true,
       },
-      name: 'Regular Expression',
+      name: 'Tweet Text (Regular Expression)',
       descriptor: 'tweets matching',
       placeholder: 'Enter a regular expression',
       function(t, e) {
         const regex = new RegExp(t.value, 'g');
 
         return !e.getFilterableText().match(regex);
+      },
+    },
+    BTD_user_regex: {
+      display: {
+        global: true,
+      },
+      name: 'Username (Regular Expression)',
+      descriptor: 'usernames matching',
+      placeholder: 'Enter a regular expression',
+      function(t, e) {
+        const regex = new RegExp(t.value, 'g');
+
+        if (e.user === undefined) {
+          return true;
+        }
+
+        return !e.user.screenName.match(regex);
       },
     },
     BTD_mute_quotes: {

--- a/src/js/util/ame.js
+++ b/src/js/util/ame.js
@@ -103,11 +103,8 @@ export default function() {
       descriptor: 'usernames matching',
       placeholder: 'Enter a regular expression',
       function(t, e) {
+        if (!e.user) return true;
         const regex = new RegExp(t.value, 'g');
-
-        if (e.user === undefined) {
-          return true;
-        }
 
         return !e.user.screenName.match(regex);
       },


### PR DESCRIPTION
This adds #516 

Wanted to do this myself already, so having the feature request come up added some more motivation.

Already discussed with @eramdam, but now with multiple regex filters present, I renamed the original "Regular Expression" filter to "Tweet Text (Regular Expression)" and the new one is called "Username (Regular Expression)"