### PR TITLE
Fix wrong browser detection.

### DIFF
--- a/src/js/util/browserHelper.js
+++ b/src/js/util/browserHelper.js
@@ -20,7 +20,7 @@ const getKey = (object, property) => {
 export const getExtensionUrl = (...args) => chrome.extension.getURL(...args);
 export const isFirefox = getUA().includes('Firefox/');
 export const isChrome = getUA().includes('Chrome/');
-export const isSafari = getUA().includes('Safari/');
+export const isSafari = getUA().includes('Safari/') && !isChrome;
 
 export const getBrowser = () => {
   if (isFirefox) {


### PR DESCRIPTION
This pull request fixes browser detection that Chrome is detected as Safari.

This happens because Chromium-based browsers also contain 'safari' in the user agent.