### PR TITLE
Remove t.co redirection even on profile website link

### DIFF
--- a/src/features/removeRedirection.ts
+++ b/src/features/removeRedirection.ts
@@ -32,7 +32,7 @@ export const maybeRemoveRedirection = makeBTDModule(({TD, settings}) => {
   };
 
   TD.services.TwitterUser.prototype.getExpandedURL = function () {
-    return this.entities.url.urls[0].expanded_url;
+    return this.entities?.url?.urls?.[0]?.expanded_url ?? this.url;
   };
 
   // Since createUrlAnchor() is not called when rendering the profile website link, modify the template.

--- a/src/features/removeRedirection.ts
+++ b/src/features/removeRedirection.ts
@@ -1,3 +1,4 @@
+import {modifyMustacheTemplate} from '../helpers/mustacheHelpers';
 import {makeBTDModule} from '../types/btdCommonTypes';
 
 /** Removes the t.co redirection on links. */
@@ -29,4 +30,16 @@ export const maybeRemoveRedirection = makeBTDModule(({TD, settings}) => {
 
     return result;
   };
+
+  TD.services.TwitterUser.prototype.getExpandedURL = function () {
+    return this.entities.url.urls[0].expanded_url;
+  };
+
+  // Since createUrlAnchor() is not called when rendering the profile website link, modify the template.
+  modifyMustacheTemplate(TD, 'twitter_profile.mustache', (template) =>
+    template.replace(
+      '{{/location}}<a href="{{url}}" class="prf-siteurl js-action-url" target="_blank">{{getDisplayURL}}',
+      '{{/location}}<a href="{{getExpandedURL}}" class="prf-siteurl js-action-url" target="_blank">{{getDisplayURL}}'
+    )
+  );
 });

--- a/src/types/tweetdeckTypes.ts
+++ b/src/types/tweetdeckTypes.ts
@@ -525,6 +525,8 @@ interface User {
   bannerUrl: string;
   bannerUrlSmall: string;
   _profileBannerURL: string;
+  prototype: this;
+  getExpandedURL(): string;
 }
 
 interface SourceUserEntities {
@@ -1098,6 +1100,7 @@ interface TwitterStatus extends TweetDeckChirp {
 interface Services {
   bitly: unknown;
   TwitterStatus: TwitterStatus;
+  TwitterUser: User;
   ChirpBase: {
     MESSAGE: string;
   };


### PR DESCRIPTION
Fixes #416.

Since the method `createUrlAnchor()` is not called when rendering the profile website link, I added template modification.