### PR TITLE
Fix usernames formatting issues

### DIFF
--- a/src/features/usernameDisplay.ts
+++ b/src/features/usernameDisplay.ts
@@ -116,7 +116,7 @@ export const maybeChangeUsernameFormat = makeBTDModule(({settings, TD}) => {
       // DM conversation headers
       replaceWrapper(
         'status/conversation_header',
-        '<b class="link-complex-target">{{{emojifiedName}}}</b> <span class="attribution username txt-mute txt-small">@{{screenName}}</span>',
+        '<b class="link-complex-target">{{{emojifiedName}}}</b> <span class="attribution username txt-mute txt-size-variable--12">@{{screenName}}</span>',
         '<b class="link-complex-target">{{screenName}}</b>'
       );
 

--- a/src/features/usernameDisplay.ts
+++ b/src/features/usernameDisplay.ts
@@ -65,7 +65,7 @@ export const maybeChangeUsernameFormat = makeBTDModule(({settings, TD}) => {
     // general fullname template
     replaceWrapper(
       'text/user_link_fullname',
-      '{{#unsafe}}{{{name}}}{{/unsafe}}{{^unsafe}}{{name}}{{/unsafe}}',
+      '{{#unsafe}}{{{name}}}{{/unsafe}}{{^unsafe}}{{{name}}}{{/unsafe}}',
       '{{#btd.usernameFromURL}}{{profileUrl}}{{/btd.usernameFromURL}}'
     );
 


### PR DESCRIPTION
This PR fixes the following issues:
- When "Name display style" is set to "Username only," screen names in DM conversation headers are displayed in duplicate.
- Notification/Activity columns show full names even if set to "Username only" or "Username and full name." (fixes #493)

Both of these issues seem to be caused by minor changes in mustache templates.