### PR TITLE
Add a setting to separate rt from qrt/account picker

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -466,5 +466,8 @@
   },
   "settings_extract_pronouns": {
     "message": "Extract pronouns from users' biography or location and show them within columns"
+  },
+  "settings_separate_tweet_and_quote_tweet_actions": {
+    "message": "Separate tweet and quote tweet buttons"
   }
 }

--- a/src/components/settings/menu/settingsTweetActions.tsx
+++ b/src/components/settings/menu/settingsTweetActions.tsx
@@ -292,6 +292,11 @@ export const SettingsTweetActions: FC<SettingsMenuSectionProps> = (props) => {
               );
             },
           },
+          {
+            initialValue: settings.separateTweetAndQuoteTweetActions,
+            key: 'separateTweetAndQuoteTweetActions',
+            label: <Trans id="settings_separate_tweet_and_quote_tweet_actions" />,
+          },
         ]}>
         <Trans id="settings_misc" />
       </CheckboxSelectSettingsRow>

--- a/src/features/addTweetActions.css
+++ b/src/features/addTweetActions.css
@@ -10,6 +10,10 @@
   content: '\F101';
 }
 
+.icon-quote::before {
+  content: '\F113';
+}
+
 .tweet-detail-actions.tweet-detail-actions {
   display: flex !important;
   padding-bottom: 8px;

--- a/src/features/changeTweetActions.ts
+++ b/src/features/changeTweetActions.ts
@@ -1,6 +1,7 @@
 import './changeTweetActions.css';
 
 import {isHTMLElement} from '../helpers/domHelpers';
+import {modifyMustacheTemplate} from '../helpers/mustacheHelpers';
 import {getChirpFromElement} from '../helpers/tweetdeckHelpers';
 import {makeBTDModule} from '../types/btdCommonTypes';
 
@@ -16,42 +17,116 @@ export const changeTweetActionsStyling = makeBTDModule(({settings, jq, TD}) => {
     String(settings.showTweetActionsOnHover)
   );
 
-  if (!settings.showAccountChoiceOnFavorite) {
-    return;
+  if (settings.showAccountChoiceOnFavorite) {
+    const usernamesAllowlist = settings.accountChoiceAllowList
+      .split(',')
+      .map((t) => t.trim().replace('@', '').toLowerCase())
+      .filter(Boolean);
+
+    jq(document).on('click', '.tweet-footer [rel="favorite"]', (e) => {
+      const chirp = getChirpFromElement(TD, e.target);
+
+      if (!chirp || !isHTMLElement(e.target) || !e.target.closest('.stream-item')) {
+        return;
+      }
+
+      const usefulChirp = chirp.chirp.targetTweet || chirp.chirp;
+
+      e.stopImmediatePropagation();
+      e.stopPropagation();
+      e.preventDefault();
+
+      if (
+        usernamesAllowlist.includes(usefulChirp.account.state.username.toLowerCase()) ||
+        usernamesAllowlist.length === 0
+      ) {
+        jq(document).trigger('uiShowFavoriteFromOptions', {
+          tweet: usefulChirp,
+        });
+        return;
+      }
+
+      usefulChirp.favorite({
+        element: jq(e.target.closest('.stream-item')!),
+        statusKey: usefulChirp.id,
+        column: chirp.extra.columnKey,
+      });
+    });
   }
 
-  const usernamesAllowlist = settings.accountChoiceAllowList
-    .split(',')
-    .map((t) => t.trim().replace('@', '').toLowerCase())
-    .filter(Boolean);
+  if (settings.separateTweetAndQuoteTweetActions) {
+    modifyMustacheTemplate(TD, 'status/tweet_single_actions.mustache', (string) => {
+      const retweetOnlyItem = `<li class="tweet-action-item pull-left margin-r--10 {{#isProtected}}is-protected-action{{/isProtected}}">
+  <a class="tweet-action {{#isProtected}}no-pointer-events{{/isProtected}}" href="#"
+    data-btd-action="retweet-only" rel="retweet-only" title="Retweet only">
+    <i class="js-icon-retweet icon icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle txt-center {{#withPrettyEngagements}}pull-left{{/withPrettyEngagements}}"></i>
+    {{#withPrettyEngagements}}
+    <span class="pull-right icon-retweet-toggle margin-l--3 margin-t--1 txt-size--12 js-retweet-count retweet-count">
+      {{#prettyRetweetCount}}{{prettyRetweetCount}}{{/prettyRetweetCount}}
+    </span>
+    {{/withPrettyEngagements}}
+    <span class="is-vishidden">{{_i}}Retweet{{/i}}</span>
+  </a>
+</li>`;
 
-  jq(document).on('click', '.tweet-footer [rel="favorite"]', (e) => {
-    const chirp = getChirpFromElement(TD, e.target);
-
-    if (!chirp || !isHTMLElement(e.target) || !e.target.closest('.stream-item')) {
-      return;
-    }
-
-    const usefulChirp = chirp.chirp.targetTweet || chirp.chirp;
-
-    e.stopImmediatePropagation();
-    e.stopPropagation();
-    e.preventDefault();
-
-    if (
-      usernamesAllowlist.includes(usefulChirp.account.state.username.toLowerCase()) ||
-      usernamesAllowlist.length === 0
-    ) {
-      jq(document).trigger('uiShowFavoriteFromOptions', {
-        tweet: usefulChirp,
-      });
-      return;
-    }
-
-    usefulChirp.favorite({
-      element: jq(e.target.closest('.stream-item')!),
-      statusKey: usefulChirp.id,
-      column: chirp.extra.columnKey,
+      const marker = '{{#getMainUser}}';
+      return string
+        .replace(
+          'icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle txt-center {{#withPrettyEngagements}}pull-left{{/withPrettyEngagements}}',
+          'icon-retweet txt-center' // icon-quote?
+        )
+        .replace(
+          '{{#withPrettyEngagements}} <span class="pull-right icon-retweet-toggle margin-l--3 margin-t--1 txt-size--12 js-retweet-count retweet-count">{{#prettyRetweetCount}}{{prettyRetweetCount}}{{/prettyRetweetCount}}</span> {{/withPrettyEngagements}}',
+          ''
+        )
+        .replace(marker, `${marker}${retweetOnlyItem}`);
     });
-  });
+
+    modifyMustacheTemplate(TD, 'status/tweet_detail_actions.mustache', (string) => {
+      const retweetOnlyItem = `<li class="tweet-detail-action-item {{#isProtected}}is-protected-action{{/isProtected}}">
+  <a class="tweet-detail-action {{#isProtected}}no-pointer-events{{/isProtected}}" href="#"
+    data-btd-action="retweet-only" rel="retweet-only" title="Retweet only">
+    <i class="js-icon-retweet icon icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle"></i>
+    <span class="is-vishidden">{{_i}}Retweet{{/i}}</span>
+  </a>
+</li>`;
+
+      const marker = '{{#getMainUser}}';
+      return string
+        .replace(
+          'icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle',
+          'icon-retweet' // icon-quote?
+        )
+        .replace(marker, `${marker}${retweetOnlyItem}`);
+    });
+
+    jq('body').on('click', '[data-btd-action="retweet-only"]', (ev) => {
+      ev.preventDefault();
+      const chirp = getChirpFromElement(TD, ev.target);
+
+      if (!chirp) {
+        return;
+      }
+
+      const usefulChirp = chirp.chirp.targetTweet || chirp.chirp;
+
+      if (!usefulChirp.isRetweeted) {
+        jq(document).trigger('uiRetweet', {
+          id: usefulChirp.id,
+          from: [usefulChirp.account.getKey()],
+        });
+        jq(document).on('dataRetweetSuccess', () => {
+          usefulChirp.setRetweeted(true);
+        });
+      } else {
+        jq(document).trigger('uiUndoRetweet', {
+          tweetId: usefulChirp.id,
+          from: usefulChirp.account.getKey(),
+        });
+        jq(document).trigger('dataUndoRetweetSuccess', () => {
+          usefulChirp.setRetweeted(false);
+        });
+      }
+    });
+  }
 });

--- a/src/features/changeTweetActions.ts
+++ b/src/features/changeTweetActions.ts
@@ -72,8 +72,8 @@ export const changeTweetActionsStyling = makeBTDModule(({settings, jq, TD}) => {
       const marker = '{{#getMainUser}}';
       return string
         .replace(
-          'icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle txt-center {{#withPrettyEngagements}}pull-left{{/withPrettyEngagements}}',
-          'icon-retweet txt-center' // icon-quote?
+          'js-icon-retweet icon icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle txt-center {{#withPrettyEngagements}}pull-left{{/withPrettyEngagements}}',
+          'icon icon-quote txt-center'
         )
         .replace(
           '{{#withPrettyEngagements}} <span class="pull-right icon-retweet-toggle margin-l--3 margin-t--1 txt-size--12 js-retweet-count retweet-count">{{#prettyRetweetCount}}{{prettyRetweetCount}}{{/prettyRetweetCount}}</span> {{/withPrettyEngagements}}',
@@ -94,8 +94,8 @@ export const changeTweetActionsStyling = makeBTDModule(({settings, jq, TD}) => {
       const marker = '{{#getMainUser}}';
       return string
         .replace(
-          'icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle',
-          'icon-retweet' // icon-quote?
+          'js-icon-retweet icon icon-retweet{{#isRetweeted}}-filled{{/isRetweeted}} icon-retweet-toggle',
+          'icon icon-quote'
         )
         .replace(marker, `${marker}${retweetOnlyItem}`);
     });

--- a/src/types/btdSettingsTypes.ts
+++ b/src/types/btdSettingsTypes.ts
@@ -161,6 +161,9 @@ export const RBetterTweetDeckSettings = t.type({
   /** Shows the number of followers in the follow actions */
   showFollowersCount: withDefault(t.boolean, true),
 
+  /** Shows separate buttons for just retweet and quote/account picker */
+  separateTweetAndQuoteTweetActions: withDefault(t.boolean, false),
+
   /** Change the display of usernames in columns. */
   usernamesFormat: withDefault(
     makeEnumRuntimeType<BTDUsernameFormat>(BTDUsernameFormat),

--- a/src/types/tweetdeckTypes.ts
+++ b/src/types/tweetdeckTypes.ts
@@ -657,6 +657,7 @@ export interface TweetDeckChirp {
     name: string;
     url: string;
   };
+  setRetweeted(isRetweeted: boolean): void;
 }
 
 export interface TweetHashtag {


### PR DESCRIPTION
This adds a button next to the original retweet button that retweets a tweet without opening the account picker popup, as I described in #575. It also removes the retweet counter indicator from the original retweet button and probably should change it a custom icon. Here's some screenshots, the new button is on the left.

![Screenshot 2021-04-17 232200](https://user-images.githubusercontent.com/4672967/115127032-c1024780-9fd3-11eb-95ed-0dc3d328dd89.jpg)

![Screenshot 2021-04-18 003809](https://user-images.githubusercontent.com/4672967/115128495-67534a80-9fde-11eb-8f06-a6193b23a7d1.jpg)

I'm not sure `changeTweetActions.ts` is the right place to add the button, but I wasn't sure how to do it in `addTweetActions.ts` without breaking the code that changes the original button (maybe change the order of the classes in the button I add?). I also didn't add the quote icon yet, and I'm not even sure it'll get merged at all since it was unprompted, so I thought I'd try and get some feedback on this as a draft.

I think the issue as I opened it came off a bit rude, sorry about that!