### PR TITLE
Specify min-height on card containers to prevent scroll jumping

### DIFF
--- a/src/features/renderCardsInColumns.css
+++ b/src/features/renderCardsInColumns.css
@@ -1,0 +1,20 @@
+[btd-render-cards='true'] .js-column:is([data-column-size='medium'], [data-column-size='small'], [data-column-size='large']) {
+  & .js-tweet[btd-card='summary_large_image'] .js-card-container {
+    min-height: 206px;
+  }
+  & .js-tweet[btd-card='745291183405076480:live_event'] .js-card-container {
+    height: 226px;
+  }
+  & .js-tweet[btd-card='summary'] .js-card-container {
+    min-height: 85px;
+  }
+  & .js-tweet[btd-card='poll2choice_text_only'] .js-card-container {
+    min-height: 112px;
+  }
+  & .js-tweet[btd-card='poll3choice_text_only'] .js-card-container {
+    min-height: 148px;
+  }
+  & .js-tweet[btd-card='poll4choice_text_only'] .js-card-container {
+    min-height: 184px;
+  }
+}

--- a/src/features/renderCardsInColumns.css
+++ b/src/features/renderCardsInColumns.css
@@ -1,20 +1,31 @@
 [btd-render-cards='true'] .js-column:is([data-column-size='medium'], [data-column-size='small'], [data-column-size='large']) {
+  /* Article preview, large */
   & .js-tweet[btd-card='summary_large_image'] .js-card-container {
     min-height: 206px;
   }
-  & .js-tweet[btd-card='745291183405076480:live_event'] .js-card-container {
-    height: 226px;
-  }
+  /* Article preview */
   & .js-tweet[btd-card='summary'] .js-card-container {
     min-height: 85px;
   }
+  /* Poll with two choices */
   & .js-tweet[btd-card='poll2choice_text_only'] .js-card-container {
     min-height: 112px;
   }
+  /* Poll with three choices */
   & .js-tweet[btd-card='poll3choice_text_only'] .js-card-container {
     min-height: 148px;
   }
+  /* Poll with 4 choices */
   & .js-tweet[btd-card='poll4choice_text_only'] .js-card-container {
     min-height: 184px;
+  }
+  /* Moment, "Events" and live videos */
+  & .js-tweet[btd-card='745291183405076480:live_event'] .js-card-container,
+  & .js-tweet[btd-card='745291183405076480:live_video'] .js-card-container {
+    height: 226px;
+  }
+  /* Player */
+  & .js-tweet[btd-card='player'] .js-card-container {
+    min-height: 85px;
   }
 }

--- a/src/features/renderCardsInColumns.css
+++ b/src/features/renderCardsInColumns.css
@@ -1,4 +1,8 @@
 [btd-render-cards='true'] .js-column:is([data-column-size='medium'], [data-column-size='small'], [data-column-size='large']) {
+  /* Cards act weird and don't load in Collections columns */
+  &[data-column-type='col_customtimeline'] .js-tweet[btd-card] .js-card-container {
+    min-height: initial !important;
+  }
   /* Article preview, large */
   & .js-tweet[btd-card='summary_large_image'] .js-card-container {
     min-height: 206px;

--- a/src/features/renderCardsInColumns.ts
+++ b/src/features/renderCardsInColumns.ts
@@ -1,5 +1,8 @@
+import './renderCardsInColumns.css';
+
 import {Dictionary} from 'lodash';
 
+import {modifyMustacheTemplate} from '../helpers/mustacheHelpers';
 import {createSelectorForChirp, getChirpFromKey} from '../helpers/tweetdeckHelpers';
 import {hasProperty} from '../helpers/typeHelpers';
 import {onVisibleChirpAdded} from '../services/chirpHandler';
@@ -17,6 +20,12 @@ export const maybeRenderCardsInColumns = makeBTDModule((options) => {
   if (!settings.showCardsInsideColumns) {
     return;
   }
+
+  document.body.setAttribute('btd-render-cards', 'true');
+
+  modifyMustacheTemplate(TD, 'status/tweet_single.mustache', (string) => {
+    return string.replace('<div class', '<div {{#card}}btd-card="{{card.name}}"{{/card}} class');
+  });
 
   type RenderCardForChirp = (
     chirp: TweetDeckChirp,

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -38,7 +38,7 @@ import {maybeChangeUsernameFormat} from './features/usernameDisplay';
 import {listenToInternalBTDMessage, sendInternalBTDMessage} from './helpers/communicationHelpers';
 import {displayTweetDeckBanner} from './helpers/tweetdeckHelpers';
 import {setupChirpHandler} from './services/chirpHandler';
-import {setupMediaSizeMonitor} from './services/columnMediaSizeMonitor';
+import {setupColumnMonitor} from './services/columnMediaSizeMonitor';
 import {maybeSetupDebugFunctions} from './services/debugMethods';
 import {insertSettingsButton} from './services/setupSettings';
 import {applyTweetDeckSettings} from './types/abstractTweetDeckSettings';
@@ -101,7 +101,7 @@ const jq: JQueryStatic | undefined =
   setupGifModals(btdModuleOptions);
   injectCustomCss(btdModuleOptions);
   maybeRenderCardsInColumns(btdModuleOptions);
-  setupMediaSizeMonitor(btdModuleOptions);
+  setupColumnMonitor(btdModuleOptions);
   maybeRemoveRedirection(btdModuleOptions);
   maybeChangeUsernameFormat(btdModuleOptions);
   maybeRevertToLegacyReplies(btdModuleOptions);

--- a/src/services/columnMediaSizeMonitor.ts
+++ b/src/services/columnMediaSizeMonitor.ts
@@ -19,6 +19,8 @@ export const setupMediaSizeMonitor = makeBTDModule(({jq}) => {
     // @ts-ignore
     const id = ev.target.closest('.js-column').getAttribute('data-column');
     const size = data.value;
+    // @ts-ignore
+    ev.target.closest('.js-column').setAttribute('data-column-size', size);
 
     if (!id) {
       return;
@@ -43,6 +45,9 @@ export const setupMediaSizeMonitor = makeBTDModule(({jq}) => {
       .filter((col) => col.id)
       .forEach((col) => {
         columnMediaSizes.set(col.id, col.mediaSize || 'medium');
+        document
+          .querySelector(`[data-column=${col.id}]`)
+          ?.setAttribute('data-column-size', col.mediaSize || 'medium');
       });
   }
 


### PR DESCRIPTION
Fixes https://github.com/eramdam/BetterTweetDeck/issues/615

This PR fixes the issue by specifying a min-height on the card containers.

- [x] ~~`3260518932:moment`~~ Seems to be replaced by `745291183405076480:live_event`
- [x] `poll2choice_text_only`
- [x] `poll3choice_text_only`
- [x] `poll4choice_text_only`
- [x] `summary`
- [x] `summary_large_image`
- [x] ~~`3691233323:periscope_broadcast`~~ Doesn't seem to be supported
- [x] ~~`audio`~~ Seems deprecated?
- [x] `player`
- [x] `745291183405076480:live_event` (this one seems buggy at times..)
- [x] `745291183405076480:live_video`