### PR TITLE
Changed links in contributors list from API responses to GitHub profiles

### DIFF
--- a/src/components/settings/components/settingsCredits.tsx
+++ b/src/components/settings/components/settingsCredits.tsx
@@ -108,7 +108,7 @@ async function getGithubContributors() {
       return {
         contributions: c.contributions,
         username: c.login,
-        url: c.url,
+        url: c.html_url,
       };
     })
     .sort((c) => -c.contributions);


### PR DESCRIPTION
I noticed that the contributors list links to the contributors’ API data, but it’s meant to return the human-viewable GitHub profile instead.