### PR TITLE
Implement "add action username" feature

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -434,6 +434,9 @@
   "settings_show_content_warnings": {
     "message": "Show content warnings for appropriately marked tweets"
   },
+  "settings_add_action_username": {
+    "message": "Add the username in the action notification"
+  },
   "settings_images": {
     "message": "Images"
   },

--- a/src/components/settings/settingsTweetContent.tsx
+++ b/src/components/settings/settingsTweetContent.tsx
@@ -90,6 +90,12 @@ export const SettingsTweetContent: FC<SettingsMenuSectionProps> = (props) => {
               </small>
             ),
           },
+          {
+            initialValue: settings.addActionUsername,
+            key: 'addActionUsername',
+            introducedIn: '4.5',
+            label: <Trans id="settings_add_action_username" />,
+          },
         ]}>
         <Trans id="settings_misc" />
       </CheckboxSelectSettingsRow>

--- a/src/features/addActionUsername.ts
+++ b/src/features/addActionUsername.ts
@@ -1,0 +1,48 @@
+import {onChirpAdded} from '../services/chirpHandler';
+import {makeBTDModule, makeBtdUuidSelector} from '../types/btdCommonTypes';
+import {TwitterActionEnum} from '../types/tweetdeckTypes';
+
+export const addActionUsername = makeBTDModule(({TD, settings}) => {
+  if (!settings.addActionUsername) {
+    return;
+  }
+
+  onChirpAdded((payload) => {
+    const chirpNode = document.querySelector(makeBtdUuidSelector('data-btd-uuid', payload.uuid));
+
+    if (!chirpNode) {
+      return;
+    }
+
+    const actionUserAnchor = chirpNode.querySelector('.nbfc > a');
+
+    if (!actionUserAnchor) {
+      return;
+    }
+
+    let screenName;
+    const action = payload.chirpExtra.action;
+    if (action === TwitterActionEnum.FOLLOW) {
+      screenName = payload.chirp.following?.screenName;
+    } else if (
+      action === TwitterActionEnum.RETWEET ||
+      action === TwitterActionEnum.RETWEETED_RETWEET ||
+      action === TwitterActionEnum.RETWEETED_MENTION ||
+      action === TwitterActionEnum.RETWEETED_MEDIA ||
+      action === TwitterActionEnum.FAVORITE ||
+      action === TwitterActionEnum.FAVORITED_RETWEET ||
+      action === TwitterActionEnum.FAVORITED_MENTION ||
+      action === TwitterActionEnum.FAVORITED_MEDIA
+    ) {
+      screenName = payload.chirp.sourceUser?.screenName;
+    } else {
+      screenName = payload.chirp.user?.screenName;
+    }
+
+    if (!screenName) {
+      return;
+    }
+
+    actionUserAnchor.appendChild(document.createTextNode(` (@${screenName})`));
+  });
+});

--- a/src/inject.ts
+++ b/src/inject.ts
@@ -1,6 +1,7 @@
 import {isObject} from 'lodash';
 import ModuleRaid, {ModuleLike} from 'moduleraid';
 
+import {addActionUsername} from './features/addActionUsername';
 import {maybeAddColumnsButtons} from './features/addColumnButtons';
 import {maybeAddTweetActions} from './features/addTweetActions';
 import {maybeAddTweetMenuItems} from './features/addTweetMenuItems';
@@ -135,6 +136,7 @@ function isModulejQuery(mod: ModuleLike | undefined): mod is JQueryStatic {
   maybeShowCharacterCount(btdModuleOptions);
   showTweetDogEars(btdModuleOptions);
   contentWarnings(btdModuleOptions);
+  addActionUsername(btdModuleOptions);
 
   jq(document).one('dataColumnsLoaded', () => {
     document.body.classList.add('btd-loaded');

--- a/src/types/btdSettingsTypes.ts
+++ b/src/types/btdSettingsTypes.ts
@@ -55,6 +55,9 @@ export const RBetterTweetDeckSettings = t.type({
   /** Detects content warnings */
   detectContentWarnings: withDefault(t.boolean, false),
 
+  /** Add action username */
+  addActionUsername: withDefault(t.boolean, false),
+
   /** Display single images using their original aspect ratio. */
   useOriginalAspectRatioForSingleImages: withDefault(t.boolean, false),
 

--- a/src/types/tweetdeckTypes.ts
+++ b/src/types/tweetdeckTypes.ts
@@ -607,6 +607,8 @@ export interface TweetDeckChirp {
   conversationMuted: boolean;
   created: string;
   entities: TweetEntities;
+  followed?: User;
+  following?: User;
   htmlText: string;
   id: string;
   inReplyToID: string | number | null;


### PR DESCRIPTION
Resolves #390.

Hello, I tried to implement a feature to add the username in the action notification.

**Before**

<img width="343" alt="Screen Shot 2021-10-08 at 20 27 17" src="https://user-images.githubusercontent.com/1425259/136645024-95b00e3f-fc01-4488-ac01-4b4445cceb92.png">

**After**

<img width="344" alt="Screen Shot 2021-10-09 at 14 17 53" src="https://user-images.githubusercontent.com/1425259/136645119-5ab7ad3b-c4ee-46ac-a101-ec6a863fa0ff.png">

Here are other several examples:

<img width="343" alt="Screen Shot 2021-10-08 at 21 06 44" src="https://user-images.githubusercontent.com/1425259/136645029-09a46385-1028-4bf7-8518-86d994fe42a6.png">

<img width="343" alt="Screen Shot 2021-10-08 at 21 07 12" src="https://user-images.githubusercontent.com/1425259/136645031-27d3dbf7-94d2-4307-a29c-c18dfacf6093.png">

<img width="341" alt="Screen Shot 2021-10-08 at 21 25 17" src="https://user-images.githubusercontent.com/1425259/136645032-d33a2267-1148-4cd2-82c2-f2406738c8a7.png">

<img width="340" alt="Screen Shot 2021-10-08 at 21 25 22" src="https://user-images.githubusercontent.com/1425259/136645033-8502be0e-6f4f-43af-8fee-925d546ee684.png">
<img width="340" alt="Screen Shot 2021-10-08 at 21 25 42" src="https://user-images.githubusercontent.com/1425259/136645036-5dab0d30-a510-4946-91cf-cfe369b6f966.png">

Any feedbacks are appreciated. 🙂 