### PR TITLE
Fix dropdown menu max-width

### DIFF
--- a/src/features/addTweetMenuItems.css
+++ b/src/features/addTweetMenuItems.css
@@ -1,3 +1,7 @@
+.dropdown-menu {
+  max-width: 21rem;
+}
+
 .dropdown-menu [data-btd-action],
 .dropdown-menu [data-btd-filter] {
   display: block;
@@ -11,4 +15,11 @@
 .dropdown-menu .is-selected [data-btd-action],
 .dropdown-menu .is-selected [data-btd-filter] {
   color: #fff;
+}
+
+.dropdown-menu .is-selectable [data-btd-action] {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }


### PR DESCRIPTION
Since we add a custom "Mute hashtag" dropdown menu item, some hashtags can be VERY long.
Tiny PR to simply set a max width of the dropdown & truncate the text of any list items