### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/helpers/domHelpers.tsx
+++ b/src/helpers/domHelpers.tsx
@@ -18,8 +18,8 @@ export const getRandomString = (length = 32) => {
 };
 
 export function replaceAt(str: string, index: number, target: string, replacement: string) {
-  const firstPart = str.substr(0, index);
-  const secondPart = str.substr(index + target.length);
+  const firstPart = str.slice(0, index);
+  const secondPart = str.slice(index + target.length);
 
   return firstPart + replacement + secondPart;
 }
@@ -33,7 +33,7 @@ export function valueAtCursor(input: HTMLInputElement | HTMLTextAreaElement) {
   const lookStart = selection.start === selection.end ? 0 : selection.start;
 
   // @ts-ignore
-  const beforeCursor = input.value.substr(lookStart, selection.end);
+  const beforeCursor = input.value.slice(lookStart, lookStart + selection.end);
 
   return {
     value: beforeCursor,

--- a/tools/uploadNightly.ts
+++ b/tools/uploadNightly.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 
 import {getLatestRepoTag} from './latestTag';
 
-const GITHUB_SHA = (process.env.GITHUB_SHA || '').substr(0, 7);
+const GITHUB_SHA = (process.env.GITHUB_SHA || '').slice(0, 7);
 const NIGHTLY_DISCORD_WEBHOOK_ID = process.env.NIGHTLY_DISCORD_WEBHOOK_ID || '';
 const NIGHTLY_DISCORD_WEBHOOK_TOKEN = process.env.NIGHTLY_DISCORD_WEBHOOK_TOKEN || '';
 const BTD_NIGHTLY_ROLE_ID = process.env.NIGHTLY_DISCORD_ROLE_ID || '';


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.