### PR TITLE
Fix CI badge error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Better TweetDeck</h1>
 <p align="center">
-<img alt="GitHub Workflow Status" src="https://img.shields.io/github/workflow/status/eramdam/bettertweetdeck/CI">
+<img alt="GitHub Workflow Status" src="https://img.shields.io/github/actions/workflow/status/eramdam/bettertweetdeck/main.yml?branch=main">
 <a href="https://better.tw/chrome">
   <img src="https://img.shields.io/chrome-web-store/v/micblkellenpbfapmcpcfhcoeohhnpob.svg" alt="Chrome Store Version">
 </a>


### PR DESCRIPTION
Sorry for another PR.😅  This is just a small fix for the "GitHub Workflow Status" badge on `README.md`. This error was introduced by the recent URL change of shields.io. You can read the details here: https://github.com/badges/shields/issues/8671.

**Before**
<img width="625" alt="Screenshot 2023-01-03 at 2 29 55" src="https://user-images.githubusercontent.com/1425259/210263464-d0be010a-bcdb-4e8a-87d5-8d2b1a9f8314.png">

**After**
<img width="455" alt="Screenshot 2023-01-03 at 2 29 43" src="https://user-images.githubusercontent.com/1425259/210263462-077d450c-05ea-419b-a8e8-a39baf15216c.png">
