### PR TITLE
Fix regression in hiding paid verified badges, config for showing gov/business as default

### DIFF
--- a/src/components/settings/menu/settingsGeneral.tsx
+++ b/src/components/settings/menu/settingsGeneral.tsx
@@ -2,9 +2,11 @@
 import {css} from '@emotion/css';
 import React, {FC, Fragment} from 'react';
 
+import businessIcon from '../../../assets/business-verified.svg';
 import clownIcon from '../../../assets/clown-icon.svg';
 import crookedIcon from '../../../assets/crooked-icon.svg';
 import dollarIcon from '../../../assets/dollar-icon.svg';
+import govermentIcon from '../../../assets/gov-verified.svg';
 import heartIcon from '../../../assets/heart-icon.svg';
 import arrowsIcon from '../../../assets/mutual-icon.svg';
 import nerdIcon from '../../../assets/nerd-checkmark.svg';
@@ -237,6 +239,17 @@ export const SettingsGeneral: FC<SettingsMenuSectionProps> = (props) => {
                   }></SettingsRadioSettingSelect>
               );
             },
+          },
+          {
+            initialValue: settings.verifiedGovernmentBusinessBadges,
+            key: 'verifiedGovernmentBusinessBadges',
+            label: (
+              <>
+                {'Display Verified badges for Business and Government officials'}
+                <BadgeIcon icon={businessIcon} />
+                <BadgeIcon icon={govermentIcon} />
+              </>
+            ),
           },
           {
             initialValue: settings.badgesOnTopOfAvatars,

--- a/src/features/blueVerified.ts
+++ b/src/features/blueVerified.ts
@@ -10,6 +10,11 @@ export const supportBlueVerified = makeBTDModule(({TD, jq, settings}) => {
     String(settings.verifiedBlueBadgeVariation)
   );
 
+  let template = '{{/isVerified}}';
+  if (settings.verifiedBlueBadges)
+    template += `{{#isBlueVerified}}<i class="js-show-tip sprite verified-badge verified-blue" title="" data-original-title='This account is subscribed to Twitter Blue.'></i>{{/isBlueVerified}}`;
+  if (settings.verifiedGovernmentBusinessBadges)
+    template += `{{#isGovernmentVerified}}<i class="js-show-tip sprite verified-badge verified-government" title="" data-original-title='This account is verified because it is a government or multilateral organization account'></i>{{/isGovernmentVerified}} {{#isBusinessVerified}}<i class="js-show-tip sprite verified-badge verified-business" title="" data-original-title="This account is verified because it's an official organization on Twitter."></i>{{/isBusinessVerified}} `;
   [
     'compose/autocomplete_twitter_user.mustache',
     'compose/in_reply_to.mustache',
@@ -23,10 +28,7 @@ export const supportBlueVerified = makeBTDModule(({TD, jq, settings}) => {
     'typeahead/typeahead_users_compose.mustache',
   ].forEach((mustache) => {
     modifyMustacheTemplate(TD, mustache, (markup) => {
-      return markup.replace(
-        '{{/isVerified}}',
-        `{{/isVerified}} {{#isBlueVerified}}<i class="js-show-tip sprite verified-badge verified-blue" title="" data-original-title='This account is subscribed to Twitter Blue.'></i>{{/isBlueVerified}} {{#isGovernmentVerified}}<i class="js-show-tip sprite verified-badge verified-government" title="" data-original-title='This account is verified because it is a government or multilateral organization account'></i>{{/isGovernmentVerified}} {{#isBusinessVerified}}<i class="js-show-tip sprite verified-badge verified-business" title="" data-original-title="This account is verified because it's an official organization on Twitter."></i>{{/isBusinessVerified}} `
-      );
+      return markup.replace('{{/isVerified}}', template);
     });
   });
 });

--- a/src/types/btdSettingsTypes.ts
+++ b/src/types/btdSettingsTypes.ts
@@ -137,6 +137,7 @@ export const RBetterTweetDeckSettings = t.type({
     makeEnumRuntimeType(BTDVerifiedBlueBadges),
     BTDVerifiedBlueBadges.BLUE
   ),
+  verifiedGovernmentBusinessBadges: withDefault(t.boolean, true),
 
   /** Where to show tweet actions. */
   tweetActionsPosition: withDefault(


### PR DESCRIPTION
I picked up a regression in 430856efde3362631cd2587c603f9fc7dbaeff3a which meant that the `verifiedBlueBadges` setting I had within the extension wasn't being accounted for as to allow the suite to display the needed checkmarks for governments and business accounts.
I have returned the functionality of this config, but I have added another checkbox that allows users to continue displaying the yellow and grey ones as they see fit.

I vibed with the continuous erasure of legacy tweetdeck's blue checkmarks, so I wanted to patch it back in. lol